### PR TITLE
fix(sequencer): submit genesis block to Bedrock on fresh start

### DIFF
--- a/sequencer/core/src/lib.rs
+++ b/sequencer/core/src/lib.rs
@@ -75,7 +75,7 @@ impl<BC: BlockSettlementClientTrait, IC: IndexerClientTrait> SequencerCore<BC, I
             .await
             .expect("Failed to create Indexer Client");
 
-        let (_tx, genesis_msg_id) = block_settlement_client
+        let (genesis_tx, genesis_msg_id) = block_settlement_client
             .create_inscribe_tx(&genesis_block)
             .expect("Failed to create inscribe tx for genesis block");
 
@@ -100,6 +100,16 @@ impl<BC: BlockSettlementClientTrait, IC: IndexerClientTrait> SequencerCore<BC, I
             info!(
                 "No database found when starting the sequencer. Creating a fresh new with the initial data in config"
             );
+
+            // Post the genesis block to Bedrock so the indexer can locate the channel
+            // start via `search_for_channel_start`, which scans backward for block_id == 1.
+            if let Err(err) = block_settlement_client
+                .submit_inscribe_tx_to_bedrock(genesis_tx)
+                .await
+            {
+                error!("Failed to post genesis block to Bedrock with error: {err:#}");
+            }
+
             let initial_commitments: Vec<nssa_core::Commitment> = config
                 .initial_commitments
                 .iter()


### PR DESCRIPTION
The sequencer created the genesis block's inscribe transaction but discarded it (`_tx`), never posting it to Bedrock. The indexer's `search_for_channel_start` scans backward through L1 blocks looking for an L2 block with `block_id == 1` to locate the channel start. Since genesis was never on L1, the search looped indefinitely, clearing its buffer on every cycle, and `current_state` was never updated past genesis.

On a fresh DB start, submit the genesis block to Bedrock immediately after creating it, mirroring what `produce_new_block` does for all subsequent blocks. On restart the genesis block is already on Bedrock from the initial run, so submission is skipped.

Fixes the `indexer_state_consistency` integration test.

