### PR TITLE
fix: correct standalone sequencer command to use config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ This will use a wallet binary built from this repo and not the one installed in 
 ### Standalone mode
 The sequencer can be run in standalone mode with:
 ```bash
-RUST_LOG=info cargo run --features standalone -p sequencer_service sequencer/service/configs/debug
+RUST_LOG=info cargo run --features standalone -p sequencer_service -- sequencer/service/configs/debug/sequencer_config.json
 ```
 
 ## Running with Docker


### PR DESCRIPTION
## 🎯 Purpose

The standalone mode command was missing the '--' separator and the full config file path. Changed from directory path to the complete config file path: sequencer/service/configs/debug/sequencer_config.json

## ⚙️ Approach

*Describe the core changes introduced by this PR.*

- [ ] Changed README command for standalon sequencer


## 🧪 How to Test

*How to verify that this PR works as intended.*

Run the command

## 🔗 Dependencies

*Link PRs that must be merged before this one.*

None

## 🔜 Future Work

*List any work intentionally left out of this PR, whether due to scope, prioritization, or pending decisions.*

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [ ] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments
