### PR TITLE
feat(sequencer): add simulate_transaction RPC endpoint

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,3 +23,6 @@ hex.workspace = true
 borsh.workspace = true
 logos-blockchain-common-http-client.workspace = true
 jsonrpsee = { workspace = true }
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,3 +22,4 @@ log.workspace = true
 hex.workspace = true
 borsh.workspace = true
 logos-blockchain-common-http-client.workspace = true
+jsonrpsee = { workspace = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod block;
 mod borsh_base64;
 pub mod config;
 pub mod transaction;
+pub mod receipt;
 
 // Module for tests utility functions
 // TODO: Compile only for tests

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,7 @@ mod borsh_base64;
 pub mod config;
 pub mod transaction;
 pub mod receipt;
+pub mod simulation;
 
 // Module for tests utility functions
 // TODO: Compile only for tests

--- a/common/src/receipt.rs
+++ b/common/src/receipt.rs
@@ -1,0 +1,53 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+use crate::HashType;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub enum TxStatus {
+    Pending,
+    Included { block_id: u64 },
+    Rejected { reason: String },
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxReceipt {
+    pub tx_hash: HashType,
+    pub status: TxStatus,
+    pub timestamp_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct RejectedTxRecord {
+    pub reason: String,
+    pub timestamp_ms: u64,
+    pub block_height: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn rejected_tx_record_borsh_roundtrip() {
+        use super::RejectedTxRecord;
+        let record = RejectedTxRecord {
+            reason: "nonce mismatch".to_owned(),
+            timestamp_ms: 1_700_000_000_000,
+            block_height: 42,
+        };
+        let encoded = borsh::to_vec(&record).unwrap();
+        let decoded: RejectedTxRecord = borsh::from_slice(&encoded).unwrap();
+        assert_eq!(record.reason, decoded.reason);
+        assert_eq!(record.timestamp_ms, decoded.timestamp_ms);
+        assert_eq!(record.block_height, decoded.block_height);
+    }
+
+    #[test]
+    fn tx_status_serde_roundtrip() {
+        use super::TxStatus;
+        let status = TxStatus::Rejected { reason: "bad sig".to_owned() };
+        let json = serde_json::to_string(&status).unwrap();
+        let back: TxStatus = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, TxStatus::Rejected { .. }));
+    }
+}

--- a/common/src/simulation.rs
+++ b/common/src/simulation.rs
@@ -1,0 +1,31 @@
+use nssa::{Account, AccountId};
+use nssa_core::{Commitment, Nullifier};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimulationResult {
+    pub success: bool,
+    pub error: Option<String>,
+    pub accounts_modified: Vec<(AccountId, Account)>,
+    pub nullifiers_created: Vec<Nullifier>,
+    pub commitments_created: Vec<Commitment>,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn simulation_result_serde_roundtrip() {
+        use super::SimulationResult;
+        let result = SimulationResult {
+            success: true,
+            error: None,
+            accounts_modified: vec![],
+            nullifiers_created: vec![],
+            commitments_created: vec![],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let back: SimulationResult = serde_json::from_str(&json).unwrap();
+        assert!(back.success);
+        assert!(back.error.is_none());
+    }
+}

--- a/common/src/transaction.rs
+++ b/common/src/transaction.rs
@@ -1,4 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
 use log::warn;
 use nssa::{AccountId, V03State, ValidatedStateDiff};
 use nssa_core::{BlockId, Timestamp};
@@ -154,6 +155,12 @@ pub enum TransactionMalformationError {
     TransactionTooLarge { size: usize, max: usize },
 }
 
+impl From<TransactionMalformationError> for ErrorObjectOwned {
+    fn from(err: TransactionMalformationError) -> Self {
+        ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), err.to_string(), None::<()>)
+    }
+}
+
 /// Returns the canonical Clock Program invocation transaction for the given block timestamp.
 /// Every valid block must end with exactly one occurrence of this transaction.
 #[must_use]
@@ -169,4 +176,33 @@ pub fn clock_invocation(timestamp: clock_core::Instruction) -> nssa::PublicTrans
         message,
         nssa::public_transaction::WitnessSet::from_raw_parts(vec![]),
     )
+}
+
+#[cfg(test)]
+mod malformation_error_tests {
+    use jsonrpsee::types::ErrorCode;
+
+    use super::*;
+
+    #[test]
+    fn from_too_large_produces_invalid_params_code() {
+        let err = TransactionMalformationError::TransactionTooLarge { size: 100, max: 50 };
+        let rpc_err: jsonrpsee::types::ErrorObjectOwned = err.into();
+        assert_eq!(rpc_err.code(), ErrorCode::InvalidParams.code());
+        assert!(rpc_err.message().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn from_failed_decode_produces_invalid_params_code() {
+        let err = TransactionMalformationError::FailedToDecode { tx: crate::HashType([0; 32]) };
+        let rpc_err: jsonrpsee::types::ErrorObjectOwned = err.into();
+        assert_eq!(rpc_err.code(), ErrorCode::InvalidParams.code());
+    }
+
+    #[test]
+    fn from_invalid_signature_produces_invalid_params_code() {
+        let err = TransactionMalformationError::InvalidSignature;
+        let rpc_err: jsonrpsee::types::ErrorObjectOwned = err.into();
+        assert_eq!(rpc_err.code(), ErrorCode::InvalidParams.code());
+    }
 }

--- a/nssa/src/validated_state_diff.rs
+++ b/nssa/src/validated_state_diff.rs
@@ -406,6 +406,18 @@ impl ValidatedStateDiff {
         self.0.public_diff.clone()
     }
 
+    /// Returns the new nullifiers produced by this transaction.
+    #[must_use]
+    pub fn new_nullifiers(&self) -> &[nssa_core::Nullifier] {
+        &self.0.new_nullifiers
+    }
+
+    /// Returns the new commitments produced by this transaction.
+    #[must_use]
+    pub fn new_commitments(&self) -> &[nssa_core::Commitment] {
+        &self.0.new_commitments
+    }
+
     pub(crate) fn into_state_diff(self) -> StateDiff {
         self.0
     }

--- a/sequencer/core/src/block_store.rs
+++ b/sequencer/core/src/block_store.rs
@@ -103,6 +103,27 @@ impl SequencerStore {
     pub fn get_nssa_state(&self) -> Option<V03State> {
         self.dbio.get_nssa_state().ok()
     }
+
+    pub fn store_rejected_tx(
+        &mut self,
+        hash: common::HashType,
+        reason: String,
+        block_height: u64,
+        timestamp_ms: u64,
+    ) -> anyhow::Result<()> {
+        use common::receipt::RejectedTxRecord;
+        let record = RejectedTxRecord { reason, timestamp_ms, block_height };
+        Ok(self.dbio.put_rejected_tx(hash, &record)?)
+    }
+
+    pub fn get_rejected_tx(&self, hash: common::HashType) -> Option<common::receipt::RejectedTxRecord> {
+        self.dbio.get_rejected_tx(hash).ok().flatten()
+    }
+
+    /// Returns the block_id that contains this transaction, or `None` if not yet included.
+    pub fn get_block_id_for_tx(&self, hash: common::HashType) -> Option<u64> {
+        self.tx_hash_to_block_map.get(&hash).copied()
+    }
 }
 
 pub(crate) fn block_to_transactions_map(block: &Block) -> HashMap<HashType, u64> {
@@ -263,5 +284,71 @@ mod tests {
             finalized_block.bedrock_status,
             common::block::BedrockStatus::Finalized
         ));
+    }
+
+    #[test]
+    fn store_and_get_rejected_tx() {
+        let temp_dir = tempdir().unwrap();
+        let signing_key = sequencer_sign_key_for_testing();
+        let genesis_block_hashable_data = HashableBlockData {
+            block_id: 0,
+            prev_block_hash: HashType([0; 32]),
+            timestamp: 0,
+            transactions: vec![],
+        };
+        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let mut store =
+            SequencerStore::open_db_with_genesis(temp_dir.path(), &genesis_block, [0; 32], signing_key)
+                .unwrap();
+
+        let hash = HashType([42; 32]);
+        store
+            .store_rejected_tx(hash, "bad nonce".to_owned(), 1, 1_000_000)
+            .unwrap();
+
+        let record = store.get_rejected_tx(hash).unwrap();
+        assert_eq!(record.reason, "bad nonce");
+        assert_eq!(record.block_height, 1);
+    }
+
+    #[test]
+    fn get_block_id_for_tx_returns_none_when_not_included() {
+        let temp_dir = tempdir().unwrap();
+        let signing_key = sequencer_sign_key_for_testing();
+        let genesis_block_hashable_data = HashableBlockData {
+            block_id: 0,
+            prev_block_hash: HashType([0; 32]),
+            timestamp: 0,
+            transactions: vec![],
+        };
+        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let store =
+            SequencerStore::open_db_with_genesis(temp_dir.path(), &genesis_block, [0; 32], signing_key)
+                .unwrap();
+
+        assert!(store.get_block_id_for_tx(HashType([1; 32])).is_none());
+    }
+
+    #[test]
+    fn get_block_id_for_tx_returns_block_id_after_inclusion() {
+        let temp_dir = tempdir().unwrap();
+        let signing_key = sequencer_sign_key_for_testing();
+        let genesis_block_hashable_data = HashableBlockData {
+            block_id: 0,
+            prev_block_hash: HashType([0; 32]),
+            timestamp: 0,
+            transactions: vec![],
+        };
+        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let mut store =
+            SequencerStore::open_db_with_genesis(temp_dir.path(), &genesis_block, [0; 32], signing_key)
+                .unwrap();
+
+        let tx = common::test_utils::produce_dummy_empty_transaction();
+        let block = common::test_utils::produce_dummy_block(1, None, vec![tx.clone()]);
+        let dummy_state = nssa::V03State::new_with_genesis_accounts(&[], vec![], 0);
+        store.update(&block, [1; 32], &dummy_state).unwrap();
+
+        assert_eq!(store.get_block_id_for_tx(tx.hash()), Some(1));
     }
 }

--- a/sequencer/core/src/lib.rs
+++ b/sequencer/core/src/lib.rs
@@ -250,6 +250,14 @@ impl<BC: BlockSettlementClientTrait, IC: IndexerClientTrait> SequencerCore<BC, I
                     error!(
                         "Transaction with hash {tx_hash} failed execution check with error: {err:#?}, skipping it",
                     );
+                    if let Err(store_err) = self.store.store_rejected_tx(
+                        tx_hash,
+                        err.to_string(),
+                        new_block_height,
+                        new_block_timestamp,
+                    ) {
+                        error!("Failed to persist rejection record for {tx_hash}: {store_err:#}");
+                    }
                     continue;
                 }
             };

--- a/sequencer/service/Cargo.toml
+++ b/sequencer/service/Cargo.toml
@@ -26,12 +26,14 @@ jsonrpsee.workspace = true
 futures.workspace = true
 bytesize.workspace = true
 borsh.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
 sequencer_core = { workspace = true, features = ["mock"] }
 bedrock_client.workspace = true
 logos-blockchain-core.workspace = true
 tempfile.workspace = true
+testnet_initial_state.workspace = true
 
 [features]
 default = []

--- a/sequencer/service/Cargo.toml
+++ b/sequencer/service/Cargo.toml
@@ -27,6 +27,12 @@ futures.workspace = true
 bytesize.workspace = true
 borsh.workspace = true
 
+[dev-dependencies]
+sequencer_core = { workspace = true, features = ["mock"] }
+bedrock_client.workspace = true
+logos-blockchain-core.workspace = true
+tempfile.workspace = true
+
 [features]
 default = []
 # Runs the sequencer in standalone mode without depending on Bedrock and Indexer services.

--- a/sequencer/service/protocol/src/lib.rs
+++ b/sequencer/service/protocol/src/lib.rs
@@ -4,6 +4,7 @@ pub use common::{
     HashType,
     block::Block,
     receipt::{TxReceipt, TxStatus},
+    simulation::SimulationResult,
     transaction::NSSATransaction,
 };
 pub use nssa::{Account, AccountId, ProgramId};

--- a/sequencer/service/protocol/src/lib.rs
+++ b/sequencer/service/protocol/src/lib.rs
@@ -1,5 +1,10 @@
 //! Reexports of types used by sequencer rpc specification.
 
-pub use common::{HashType, block::Block, transaction::NSSATransaction};
+pub use common::{
+    HashType,
+    block::Block,
+    receipt::{TxReceipt, TxStatus},
+    transaction::NSSATransaction,
+};
 pub use nssa::{Account, AccountId, ProgramId};
 pub use nssa_core::{BlockId, Commitment, MembershipProof, account::Nonce};

--- a/sequencer/service/rpc/src/lib.rs
+++ b/sequencer/service/rpc/src/lib.rs
@@ -7,7 +7,7 @@ use jsonrpsee::types::ErrorObjectOwned;
 pub use jsonrpsee::{core::ClientError, http_client::HttpClientBuilder as SequencerClientBuilder};
 use sequencer_service_protocol::{
     Account, AccountId, Block, BlockId, Commitment, HashType, MembershipProof, NSSATransaction,
-    Nonce, ProgramId, TxReceipt,
+    Nonce, ProgramId, SimulationResult, TxReceipt,
 };
 
 #[cfg(all(not(feature = "server"), not(feature = "client")))]
@@ -75,6 +75,12 @@ pub trait Rpc {
         &self,
         tx_hash: HashType,
     ) -> Result<TxReceipt, ErrorObjectOwned>;
+
+    #[method(name = "simulateTransaction")]
+    async fn simulate_transaction(
+        &self,
+        tx: NSSATransaction,
+    ) -> Result<SimulationResult, ErrorObjectOwned>;
 
     #[method(name = "getAccountsNonces")]
     async fn get_accounts_nonces(

--- a/sequencer/service/rpc/src/lib.rs
+++ b/sequencer/service/rpc/src/lib.rs
@@ -7,7 +7,7 @@ use jsonrpsee::types::ErrorObjectOwned;
 pub use jsonrpsee::{core::ClientError, http_client::HttpClientBuilder as SequencerClientBuilder};
 use sequencer_service_protocol::{
     Account, AccountId, Block, BlockId, Commitment, HashType, MembershipProof, NSSATransaction,
-    Nonce, ProgramId,
+    Nonce, ProgramId, TxReceipt,
 };
 
 #[cfg(all(not(feature = "server"), not(feature = "client")))]
@@ -69,6 +69,12 @@ pub trait Rpc {
         &self,
         tx_hash: HashType,
     ) -> Result<Option<NSSATransaction>, ErrorObjectOwned>;
+
+    #[method(name = "getTransactionReceipt")]
+    async fn get_transaction_receipt(
+        &self,
+        tx_hash: HashType,
+    ) -> Result<TxReceipt, ErrorObjectOwned>;
 
     #[method(name = "getAccountsNonces")]
     async fn get_accounts_nonces(

--- a/sequencer/service/src/service.rs
+++ b/sequencer/service/src/service.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::{BTreeMap, HashSet}, sync::Arc};
 
 use common::transaction::{NSSATransaction, TransactionMalformationError};
 use jsonrpsee::{
@@ -23,10 +23,11 @@ pub struct SequencerService<BC: BlockSettlementClientTrait, IC: IndexerClientTra
     sequencer: Arc<Mutex<SequencerCore<BC, IC>>>,
     mempool_handle: MemPoolHandle<NSSATransaction>,
     max_block_size: u64,
+    pending_txs: Arc<Mutex<HashSet<HashType>>>,
 }
 
 impl<BC: BlockSettlementClientTrait, IC: IndexerClientTrait> SequencerService<BC, IC> {
-    pub const fn new(
+    pub fn new(
         sequencer: Arc<Mutex<SequencerCore<BC, IC>>>,
         mempool_handle: MemPoolHandle<NSSATransaction>,
         max_block_size: u64,
@@ -35,6 +36,7 @@ impl<BC: BlockSettlementClientTrait, IC: IndexerClientTrait> SequencerService<BC
             sequencer,
             mempool_handle,
             max_block_size,
+            pending_txs: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 }
@@ -74,6 +76,8 @@ impl<BC: BlockSettlementClientTrait + Send + 'static, IC: IndexerClientTrait + S
             .push(authenticated_tx)
             .await
             .expect("Mempool is closed, this is a bug");
+
+        self.pending_txs.lock().await.insert(tx_hash);
 
         Ok(tx_hash)
     }
@@ -130,6 +134,44 @@ impl<BC: BlockSettlementClientTrait + Send + 'static, IC: IndexerClientTrait + S
     ) -> Result<Option<NSSATransaction>, ErrorObjectOwned> {
         let sequencer = self.sequencer.lock().await;
         Ok(sequencer.block_store().get_transaction_by_hash(tx_hash))
+    }
+
+    async fn get_transaction_receipt(
+        &self,
+        tx_hash: HashType,
+    ) -> Result<common::receipt::TxReceipt, ErrorObjectOwned> {
+        use common::receipt::{TxReceipt, TxStatus};
+
+        let sequencer = self.sequencer.lock().await;
+
+        // 1. Rejected store: durable, survives restarts.
+        if let Some(record) = sequencer.block_store().get_rejected_tx(tx_hash) {
+            return Ok(TxReceipt {
+                tx_hash,
+                status: TxStatus::Rejected { reason: record.reason },
+                timestamp_ms: Some(record.timestamp_ms),
+            });
+        }
+
+        // 2. Block store: finalized and pending blocks.
+        if let Some(block_id) = sequencer.block_store().get_block_id_for_tx(tx_hash) {
+            return Ok(TxReceipt {
+                tx_hash,
+                status: TxStatus::Included { block_id },
+                timestamp_ms: None,
+            });
+        }
+
+        // Release the sequencer lock before checking the pending set.
+        drop(sequencer);
+
+        // 3. Pending set: submitted to mempool but not yet in a block.
+        if self.pending_txs.lock().await.contains(&tx_hash) {
+            return Ok(TxReceipt { tx_hash, status: TxStatus::Pending, timestamp_ms: None });
+        }
+
+        // 4. Unknown: never submitted, invalid hash, or set was evicted.
+        Ok(TxReceipt { tx_hash, status: TxStatus::Unknown, timestamp_ms: None })
     }
 
     async fn get_accounts_nonces(
@@ -264,5 +306,32 @@ mod tests {
         let result = service.send_transaction(tx).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_hash);
+    }
+
+    #[tokio::test]
+    async fn get_receipt_returns_pending_after_submit() {
+        use sequencer_service_rpc::RpcServer as _;
+        let service = make_service().await;
+        let tx = common::test_utils::produce_dummy_empty_transaction();
+        let tx_hash = tx.hash();
+        service.send_transaction(tx).await.unwrap();
+        let receipt = service.get_transaction_receipt(tx_hash).await.unwrap();
+        assert!(
+            matches!(receipt.status, common::receipt::TxStatus::Pending)
+                || matches!(receipt.status, common::receipt::TxStatus::Included { .. }),
+            "Expected Pending or Included, got {:?}",
+            receipt.status
+        );
+    }
+
+    #[tokio::test]
+    async fn get_receipt_returns_unknown_for_unseen_hash() {
+        use sequencer_service_rpc::RpcServer as _;
+        let service = make_service().await;
+        let receipt = service
+            .get_transaction_receipt(HashType([0xff; 32]))
+            .await
+            .unwrap();
+        assert!(matches!(receipt.status, common::receipt::TxStatus::Unknown));
     }
 }

--- a/sequencer/service/src/service.rs
+++ b/sequencer/service/src/service.rs
@@ -142,28 +142,43 @@ impl<BC: BlockSettlementClientTrait + Send + 'static, IC: IndexerClientTrait + S
     ) -> Result<common::receipt::TxReceipt, ErrorObjectOwned> {
         use common::receipt::{TxReceipt, TxStatus};
 
-        let sequencer = self.sequencer.lock().await;
+        // Check durable tiers under the sequencer lock, then release it before
+        // touching `pending_txs` to preserve lock-ordering invariants.
+        let terminal_receipt = {
+            let sequencer = self.sequencer.lock().await;
 
-        // 1. Rejected store: durable, survives restarts.
-        if let Some(record) = sequencer.block_store().get_rejected_tx(tx_hash) {
-            return Ok(TxReceipt {
-                tx_hash,
-                status: TxStatus::Rejected { reason: record.reason },
-                timestamp_ms: Some(record.timestamp_ms),
-            });
+            // 1. Rejected store: durable, survives restarts.
+            if let Some(record) = sequencer.block_store().get_rejected_tx(tx_hash) {
+                Some(TxReceipt {
+                    tx_hash,
+                    status: TxStatus::Rejected { reason: record.reason },
+                    timestamp_ms: Some(record.timestamp_ms),
+                })
+            // 2. Block store: finalized and pending blocks.
+            } else if let Some(block_id) = sequencer.block_store().get_block_id_for_tx(tx_hash) {
+                let timestamp_ms = sequencer
+                    .block_store()
+                    .get_block_at_id(block_id)
+                    .ok()
+                    .flatten()
+                    .map(|b| b.header.timestamp);
+                Some(TxReceipt {
+                    tx_hash,
+                    status: TxStatus::Included { block_id },
+                    timestamp_ms,
+                })
+            } else {
+                None
+            }
+            // Sequencer lock released here.
+        };
+
+        if let Some(receipt) = terminal_receipt {
+            // Lazy eviction: TX has reached a terminal state; prune it from the
+            // pending set so `pending_txs` does not grow without bound.
+            self.pending_txs.lock().await.remove(&tx_hash);
+            return Ok(receipt);
         }
-
-        // 2. Block store: finalized and pending blocks.
-        if let Some(block_id) = sequencer.block_store().get_block_id_for_tx(tx_hash) {
-            return Ok(TxReceipt {
-                tx_hash,
-                status: TxStatus::Included { block_id },
-                timestamp_ms: None,
-            });
-        }
-
-        // Release the sequencer lock before checking the pending set.
-        drop(sequencer);
 
         // 3. Pending set: submitted to mempool but not yet in a block.
         if self.pending_txs.lock().await.contains(&tx_hash) {

--- a/sequencer/service/src/service.rs
+++ b/sequencer/service/src/service.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use common::transaction::NSSATransaction;
+use common::transaction::{NSSATransaction, TransactionMalformationError};
 use jsonrpsee::{
     core::async_trait,
     types::{ErrorCode, ErrorObjectOwned},
@@ -49,30 +49,26 @@ impl<BC: BlockSettlementClientTrait + Send + 'static, IC: IndexerClientTrait + S
 
         let tx_hash = tx.hash();
 
-        let encoded_tx =
-            borsh::to_vec(&tx).expect("Transaction borsh serialization should not fail");
-        let tx_size = u64::try_from(encoded_tx.len()).expect("Transaction size should fit in u64");
+        let encoded_tx = borsh::to_vec(&tx).map_err(|_| {
+            ErrorObjectOwned::from(TransactionMalformationError::FailedToDecode { tx: tx_hash })
+        })?;
+        let tx_size = u64::try_from(encoded_tx.len()).unwrap_or(u64::MAX);
 
         let max_tx_size = self.max_block_size.saturating_sub(BLOCK_HEADER_OVERHEAD);
 
         if tx_size > max_tx_size {
-            return Err(ErrorObjectOwned::owned(
-                ErrorCode::InvalidParams.code(),
-                format!("Transaction too large: size {tx_size}, max {max_tx_size}"),
-                None::<()>,
+            return Err(ErrorObjectOwned::from(
+                TransactionMalformationError::TransactionTooLarge {
+                    size: encoded_tx.len(),
+                    max: usize::try_from(max_tx_size).unwrap_or(usize::MAX),
+                },
             ));
         }
 
         let authenticated_tx = tx
             .transaction_stateless_check()
             .inspect_err(|err| warn!("Error at pre_check {err:#?}"))
-            .map_err(|err| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    format!("{err:?}"),
-                    None::<()>,
-                )
-            })?;
+            .map_err(ErrorObjectOwned::from)?;
 
         self.mempool_handle
             .push(authenticated_tx)
@@ -180,4 +176,93 @@ impl<BC: BlockSettlementClientTrait + Send + 'static, IC: IndexerClientTrait + S
 
 fn internal_error(err: &DbError) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(ErrorCode::InternalError.code(), err.to_string(), None::<()>)
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::shadow_unrelated, reason = "We don't care about it in tests")]
+
+    use std::{sync::Arc, time::Duration};
+
+    use bedrock_client::BackoffConfig;
+    use common::test_utils::sequencer_sign_key_for_testing;
+    use jsonrpsee::types::ErrorCode;
+    use logos_blockchain_core::mantle::ops::channel::ChannelId;
+    use sequencer_core::{
+        config::{BedrockConfig, SequencerConfig},
+        mock::SequencerCoreWithMockClients,
+    };
+    use tokio::sync::Mutex;
+
+    use super::*;
+
+    fn test_config() -> SequencerConfig {
+        let tempdir = tempfile::tempdir().unwrap();
+        SequencerConfig {
+            home: tempdir.into_path(),
+            genesis_id: 1,
+            is_genesis_random: false,
+            max_num_tx_in_block: 10,
+            max_block_size: bytesize::ByteSize::b(512),
+            mempool_max_size: 10000,
+            block_create_timeout: Duration::from_secs(1),
+            signing_key: *sequencer_sign_key_for_testing().value(),
+            bedrock_config: BedrockConfig {
+                backoff: BackoffConfig {
+                    start_delay: Duration::from_millis(100),
+                    max_retries: 5,
+                },
+                channel_id: ChannelId::from([0; 32]),
+                node_url: "http://not-used-in-tests".parse().unwrap(),
+                auth: None,
+            },
+            retry_pending_blocks_timeout: Duration::from_mins(4),
+            indexer_rpc_url: "ws://localhost:8779".parse().unwrap(),
+            initial_public_accounts: None,
+            initial_private_accounts: None,
+        }
+    }
+
+    async fn make_service(
+    ) -> SequencerService<
+        sequencer_core::mock::MockBlockSettlementClient,
+        sequencer_core::mock::MockIndexerClient,
+    > {
+        let config = test_config();
+        let (core, mempool_handle) =
+            SequencerCoreWithMockClients::start_from_config(config).await;
+        let arc_core = Arc::new(Mutex::new(core));
+        SequencerService::new(arc_core, mempool_handle, 512)
+    }
+
+    #[tokio::test]
+    async fn send_transaction_too_large_returns_invalid_params() {
+        use sequencer_service_rpc::RpcServer as _;
+        let tiny_service = {
+            let config2 = SequencerConfig {
+                max_block_size: bytesize::ByteSize::b(1),
+                ..test_config()
+            };
+            let (core2, mh2) =
+                SequencerCoreWithMockClients::start_from_config(config2).await;
+            SequencerService::new(Arc::new(Mutex::new(core2)), mh2, 1)
+        };
+        let tx = common::test_utils::produce_dummy_empty_transaction();
+        let result = tiny_service.send_transaction(tx).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidParams.code());
+        assert!(err.message().contains("too large") || err.message().contains("exceeds maximum"));
+    }
+
+    #[tokio::test]
+    async fn send_valid_transaction_returns_hash() {
+        use sequencer_service_rpc::RpcServer as _;
+        let service = make_service().await;
+        let tx = common::test_utils::produce_dummy_empty_transaction();
+        let expected_hash = tx.hash();
+        let result = service.send_transaction(tx).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected_hash);
+    }
 }

--- a/sequencer/service/src/service.rs
+++ b/sequencer/service/src/service.rs
@@ -1,5 +1,6 @@
 use std::{collections::{BTreeMap, HashSet}, sync::Arc};
 
+use chrono;
 use common::transaction::{NSSATransaction, TransactionMalformationError};
 use jsonrpsee::{
     core::async_trait,
@@ -189,6 +190,47 @@ impl<BC: BlockSettlementClientTrait + Send + 'static, IC: IndexerClientTrait + S
         Ok(TxReceipt { tx_hash, status: TxStatus::Unknown, timestamp_ms: None })
     }
 
+    async fn simulate_transaction(
+        &self,
+        tx: NSSATransaction,
+    ) -> Result<common::simulation::SimulationResult, ErrorObjectOwned> {
+        use common::simulation::SimulationResult;
+
+        // 1. Stateless check -- no lock required.
+        let tx = tx
+            .transaction_stateless_check()
+            .inspect_err(|err| warn!("simulate_transaction: stateless check failed: {err:#?}"))
+            .map_err(ErrorObjectOwned::from)?;
+
+        // 2. Clone state under lock, then release immediately.
+        let (state_clone, block_id, timestamp_ms) = {
+            let sequencer = self.sequencer.lock().await;
+            let block_id = sequencer.chain_height() + 1;
+            let timestamp_ms = u64::try_from(chrono::Utc::now().timestamp_millis())
+                .expect("current timestamp must be positive");
+            (sequencer.state().clone(), block_id, timestamp_ms)
+        };
+        // Lock is released here. Simulation runs concurrently with block production.
+
+        // 3. Execute on the cloned state -- never committed.
+        match tx.validate_on_state(&state_clone, block_id, timestamp_ms) {
+            Ok(diff) => Ok(SimulationResult {
+                success: true,
+                error: None,
+                accounts_modified: diff.public_diff().into_iter().collect(),
+                nullifiers_created: diff.new_nullifiers().to_vec(),
+                commitments_created: diff.new_commitments().to_vec(),
+            }),
+            Err(err) => Ok(SimulationResult {
+                success: false,
+                error: Some(err.to_string()),
+                accounts_modified: vec![],
+                nullifiers_created: vec![],
+                commitments_created: vec![],
+            }),
+        }
+    }
+
     async fn get_accounts_nonces(
         &self,
         account_ids: Vec<AccountId>,
@@ -348,5 +390,39 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(receipt.status, common::receipt::TxStatus::Unknown));
+    }
+
+    #[tokio::test]
+    async fn simulate_valid_transaction_returns_success() {
+        use sequencer_service_rpc::RpcServer as _;
+        let service = make_service().await;
+        let tx = common::test_utils::produce_dummy_empty_transaction();
+        let result = service.simulate_transaction(tx).await.unwrap();
+        assert!(result.success, "Expected success, got error: {:?}", result.error);
+    }
+
+    #[tokio::test]
+    async fn simulate_does_not_modify_state() {
+        use sequencer_service_rpc::RpcServer as _;
+        let service = make_service().await;
+        let tx = common::test_utils::produce_dummy_empty_transaction();
+
+        // Simulate the transaction.
+        let sim_result = service.simulate_transaction(tx.clone()).await.unwrap();
+        assert!(sim_result.success);
+
+        // The state read via get_account should be unchanged after simulation.
+        use testnet_initial_state::initial_pub_accounts_private_keys;
+        let keys = initial_pub_accounts_private_keys();
+        let account_id = keys[0].account_id;
+        let account_before = service.get_account(account_id).await.unwrap();
+
+        // Simulate again -- state should not change.
+        let tx2 = common::test_utils::produce_dummy_empty_transaction();
+        let sim_result2 = service.simulate_transaction(tx2).await.unwrap();
+        assert!(sim_result2.success);
+
+        let account_after = service.get_account(account_id).await.unwrap();
+        assert_eq!(account_before.nonce, account_after.nonce, "Simulation must not modify state");
     }
 }

--- a/storage/src/sequencer/mod.rs
+++ b/storage/src/sequencer/mod.rs
@@ -29,6 +29,9 @@ pub const DB_NSSA_STATE_KEY: &str = "nssa_state";
 /// Name of state column family.
 pub const CF_NSSA_STATE_NAME: &str = "cf_nssa_state";
 
+/// Name of the rejected-transaction column family.
+pub const CF_REJECTED_TX_NAME: &str = "cf_rejected_tx";
+
 pub struct RocksDBIO {
     pub db: DBWithThreadMode<MultiThreaded>,
 }
@@ -51,6 +54,7 @@ impl RocksDBIO {
         let cfb = ColumnFamilyDescriptor::new(CF_BLOCK_NAME, cf_opts.clone());
         let cfmeta = ColumnFamilyDescriptor::new(CF_META_NAME, cf_opts.clone());
         let cfstate = ColumnFamilyDescriptor::new(CF_NSSA_STATE_NAME, cf_opts.clone());
+        let cfrejected = ColumnFamilyDescriptor::new(CF_REJECTED_TX_NAME, cf_opts.clone());
 
         let mut db_opts = Options::default();
         db_opts.create_missing_column_families(true);
@@ -58,7 +62,7 @@ impl RocksDBIO {
         let db = DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
             &db_opts,
             path,
-            vec![cfb, cfmeta, cfstate],
+            vec![cfb, cfmeta, cfstate, cfrejected],
         )
         .map_err(|err| DbError::RocksDbError {
             error: err,
@@ -117,6 +121,50 @@ impl RocksDBIO {
         self.db
             .cf_handle(CF_NSSA_STATE_NAME)
             .expect("State should exist")
+    }
+
+    pub fn rejected_tx_column(&self) -> Arc<BoundColumnFamily<'_>> {
+        self.db
+            .cf_handle(CF_REJECTED_TX_NAME)
+            .expect("Rejected TX column should exist")
+    }
+
+    pub fn put_rejected_tx(
+        &self,
+        hash: common::HashType,
+        record: &common::receipt::RejectedTxRecord,
+    ) -> crate::DbResult<()> {
+        let cf = self.rejected_tx_column();
+        let value = borsh::to_vec(record).map_err(|err| {
+            crate::error::DbError::borsh_cast_message(
+                err,
+                Some("Failed to serialize RejectedTxRecord".to_owned()),
+            )
+        })?;
+        self.db
+            .put_cf(&cf, hash.as_ref(), value)
+            .map_err(|err| crate::error::DbError::rocksdb_cast_message(err, None))
+    }
+
+    pub fn get_rejected_tx(
+        &self,
+        hash: common::HashType,
+    ) -> crate::DbResult<Option<common::receipt::RejectedTxRecord>> {
+        let cf = self.rejected_tx_column();
+        let bytes = self
+            .db
+            .get_cf(&cf, hash.as_ref())
+            .map_err(|err| crate::error::DbError::rocksdb_cast_message(err, None))?;
+        bytes
+            .map(|b| {
+                borsh::from_slice::<common::receipt::RejectedTxRecord>(&b).map_err(|err| {
+                    crate::error::DbError::borsh_cast_message(
+                        err,
+                        Some("Failed to deserialize RejectedTxRecord".to_owned()),
+                    )
+                })
+            })
+            .transpose()
     }
 
     // Meta


### PR DESCRIPTION
## Summary

Adds a `simulate_transaction` RPC method that executes a transaction against a snapshot of the current state and returns a structured result without ever committing the changes.

Callers can use this to:

- Check whether a transaction will succeed before broadcasting it
- Inspect which accounts will be modified, what nullifiers will be created, and what commitments will be added
- Surface human-readable error messages without wasting a real submission

### Design

The implementation follows a clone-and-discard pattern:

1. Stateless signature/structure checks run without acquiring any lock.
2. The sequencer lock is acquired, `V03State` is cloned, the lock is released immediately.
3. `validate_on_state` runs on the clone, never on the real state, so block production continues concurrently without contention.
4. The resulting diff (or error) is returned without being applied.

The simulation result includes:

| Field | Contents |
|---|---|
| `success` | whether the transaction would succeed |
| `error` | failure reason if `success == false` |
| `accounts_modified` | `Vec<(AccountId, Account)>` post-state for each touched account |
| `nullifiers_created` | nullifiers that would be spent |
| `commitments_created` | commitments that would be added |

### Changes

- **`common/src/simulation.rs`** (new), `SimulationResult` type.
- **`common/src/lib.rs`**, expose `pub mod simulation`.
- **`nssa/src/validated_state_diff.rs`**, expose `new_nullifiers()` and `new_commitments()` accessors on `ValidatedStateDiff` (previously only `public_diff()` was public).
- **`sequencer/service/src/service.rs`**, `simulate_transaction` implementation with lock-release-before-execute pattern.
- **`sequencer/service/rpc/src/lib.rs`** and **`sequencer/service/protocol/src/lib.rs`**, RPC trait method and protocol type exports.

### Stacking note

This PR builds on top of #442 (receipt system) and #441 (crash fix). The
meaningful change in this PR starts at the `feat(common): add SimulationResult`
commit.

## Test plan

- [ ] `cargo test -p sequencer_service simulate`, two tests: `simulate_valid_transaction_returns_success` and `simulate_does_not_modify_state`
- [ ] Manual: simulate a token transfer; confirm `accounts_modified` shows the expected balance delta and the real account state is unchanged after the call
- [ ] Manual: simulate a transaction that should fail (e.g., insufficient balance); confirm `success == false` and `error` contains a readable message
- [ ] Load test: run N concurrent `simulate_transaction` calls while block production is active; confirm no lock contention and no state corruption