### PR TITLE
feat(wallet-ffi): expose stable identity lookup primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10477,11 +10477,13 @@ name = "wallet-ffi"
 version = "0.1.0"
 dependencies = [
  "cbindgen",
+ "k256",
  "key_protocol",
  "nssa",
  "nssa_core",
  "sequencer_service_rpc",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "wallet",

--- a/wallet-ffi/Cargo.toml
+++ b/wallet-ffi/Cargo.toml
@@ -19,6 +19,8 @@ sequencer_service_rpc = { workspace = true, features = ["client"] }
 tokio.workspace = true
 key_protocol.workspace = true
 serde_json.workspace = true
+k256.workspace = true
+sha2 = "0.10"
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/wallet-ffi/src/keys.rs
+++ b/wallet-ffi/src/keys.rs
@@ -145,6 +145,172 @@ pub unsafe extern "C" fn wallet_ffi_get_private_account_keys(
     WalletFfiError::Success
 }
 
+/// Return the keys of the first private accounts key chain in the wallet.
+///
+/// The first chain is determined by BTreeMap ordering over chain indices,
+/// which is deterministic — calling this function on a wallet persisted to
+/// disk and reopened later returns the same NPK as long as no preceding
+/// chain index was inserted in between.
+///
+/// Intended for clients (e.g. agent runtimes) that need a stable
+/// cryptographic identity derived from the wallet seed without rotating
+/// it at every call to `wallet_ffi_create_private_accounts_key`.
+///
+/// # Parameters
+/// - `handle`: Valid wallet handle
+/// - `out_keys`: Output pointer for the key material
+///
+/// # Returns
+/// - `Success` on success
+/// - `AccountNotFound` if the wallet has no private accounts key yet
+/// - Error code on other failures
+///
+/// # Memory
+/// The keys must be freed with `wallet_ffi_free_private_account_keys()`.
+///
+/// # Safety
+/// - `handle` must be a valid wallet handle from `wallet_ffi_create_new` or `wallet_ffi_open`
+/// - `out_keys` must be a valid pointer to a `FfiPrivateAccountKeys` struct
+#[no_mangle]
+pub unsafe extern "C" fn wallet_ffi_get_first_private_accounts_key(
+    handle: *mut WalletHandle,
+    out_keys: *mut FfiPrivateAccountKeys,
+) -> WalletFfiError {
+    let wrapper = match get_wallet(handle) {
+        Ok(w) => w,
+        Err(e) => return e,
+    };
+
+    if out_keys.is_null() {
+        print_error("Null pointer argument");
+        return WalletFfiError::NullPointer;
+    }
+
+    let wallet = match wrapper.core.lock() {
+        Ok(w) => w,
+        Err(e) => {
+            print_error(format!("Failed to lock wallet: {e}"));
+            return WalletFfiError::InternalError;
+        }
+    };
+
+    let Some(key_chain) = wallet.first_private_accounts_key_chain() else {
+        print_error("Wallet has no private accounts key");
+        return WalletFfiError::AccountNotFound;
+    };
+
+    let npk_bytes = key_chain.nullifier_public_key.0;
+
+    let vpk_bytes = key_chain.viewing_public_key.to_bytes();
+    let vpk_len = vpk_bytes.len();
+    let vpk_vec = vpk_bytes.to_vec();
+    let vpk_boxed = vpk_vec.into_boxed_slice();
+    #[expect(
+        clippy::as_conversions,
+        reason = "We need to convert the boxed slice into a raw pointer for FFI"
+    )]
+    let vpk_ptr = Box::into_raw(vpk_boxed) as *const u8;
+
+    unsafe {
+        (*out_keys).nullifier_public_key.data = npk_bytes;
+        (*out_keys).viewing_public_key = vpk_ptr;
+        (*out_keys).viewing_public_key_len = vpk_len;
+    }
+
+    WalletFfiError::Success
+}
+
+/// Return the keys of the private accounts key node at a specific chain
+/// index. The chain index is given as the wallet-CLI string format,
+/// e.g. "/" for the root node, "/0" for the first child, "/0/1" for a
+/// nested node, etc.
+///
+/// Intended for clients that need a stable cryptographic identity
+/// anchored on a known position in the key tree. Combined with the root
+/// node "/" seeded automatically by `WalletCore::new_init_storage`, this
+/// gives a deterministic agent identity that survives wallet reopen
+/// without any side-car cache.
+///
+/// # Parameters
+/// - `handle`: Valid wallet handle
+/// - `chain_index_str`: Null-terminated UTF-8 chain index path
+/// - `out_keys`: Output pointer for the key material
+///
+/// # Returns
+/// - `Success` on success
+/// - `InvalidUtf8` if `chain_index_str` is malformed
+/// - `AccountNotFound` if no node exists at the given chain index
+/// - Error code on other failures
+///
+/// # Memory
+/// The keys must be freed with `wallet_ffi_free_private_account_keys()`.
+///
+/// # Safety
+/// - `handle` must be a valid wallet handle from `wallet_ffi_create_new` or `wallet_ffi_open`
+/// - `chain_index_str` must be a valid null-terminated UTF-8 string
+/// - `out_keys` must be a valid pointer to a `FfiPrivateAccountKeys` struct
+#[no_mangle]
+pub unsafe extern "C" fn wallet_ffi_get_private_accounts_key_by_chain_index(
+    handle: *mut WalletHandle,
+    chain_index_str: *const std::ffi::c_char,
+    out_keys: *mut FfiPrivateAccountKeys,
+) -> WalletFfiError {
+    use key_protocol::key_management::key_tree::chain_index::ChainIndex;
+    use std::str::FromStr;
+
+    let wrapper = match get_wallet(handle) {
+        Ok(w) => w,
+        Err(e) => return e,
+    };
+
+    if chain_index_str.is_null() || out_keys.is_null() {
+        print_error("Null pointer argument");
+        return WalletFfiError::NullPointer;
+    }
+
+    let Ok(chain_index_str) = crate::c_str_to_string(chain_index_str, "chain_index_str") else {
+        return WalletFfiError::InvalidUtf8;
+    };
+
+    let Ok(chain_index) = ChainIndex::from_str(&chain_index_str) else {
+        print_error(format!("Failed to parse chain index: {chain_index_str}"));
+        return WalletFfiError::InvalidKeyValue;
+    };
+
+    let wallet = match wrapper.core.lock() {
+        Ok(w) => w,
+        Err(e) => {
+            print_error(format!("Failed to lock wallet: {e}"));
+            return WalletFfiError::InternalError;
+        }
+    };
+
+    let Some(key_chain) = wallet.private_accounts_key_chain_by_index(&chain_index) else {
+        print_error(format!("No private accounts key at chain index {chain_index_str}"));
+        return WalletFfiError::AccountNotFound;
+    };
+
+    let npk_bytes = key_chain.nullifier_public_key.0;
+
+    let vpk_bytes = key_chain.viewing_public_key.to_bytes();
+    let vpk_len = vpk_bytes.len();
+    let vpk_vec = vpk_bytes.to_vec();
+    let vpk_boxed = vpk_vec.into_boxed_slice();
+    #[expect(
+        clippy::as_conversions,
+        reason = "We need to convert the boxed slice into a raw pointer for FFI"
+    )]
+    let vpk_ptr = Box::into_raw(vpk_boxed) as *const u8;
+
+    unsafe {
+        (*out_keys).nullifier_public_key.data = npk_bytes;
+        (*out_keys).viewing_public_key = vpk_ptr;
+        (*out_keys).viewing_public_key_len = vpk_len;
+    }
+
+    WalletFfiError::Success
+}
+
 /// Free private account keys returned by `wallet_ffi_get_private_account_keys`.
 ///
 /// # Safety

--- a/wallet-ffi/src/keys.rs
+++ b/wallet-ffi/src/keys.rs
@@ -311,6 +311,124 @@ pub unsafe extern "C" fn wallet_ffi_get_private_accounts_key_by_chain_index(
     WalletFfiError::Success
 }
 
+/// FFI signature shape produced by `wallet_ffi_sign_message_at_chain_index`.
+///
+/// `signature` is a 64-byte BIP-340 Schnorr-over-secp256k1 signature.
+/// `verifying_public_key` is the 32-byte x-only public key matching the
+/// signing key derived at the specified chain index. Both arrays are
+/// inlined by value — no allocation, no free function needed.
+#[repr(C)]
+pub struct FfiCardSignature {
+    pub signature: [u8; 64],
+    pub verifying_public_key: [u8; 32],
+}
+
+/// Sign an arbitrary message with the private accounts key at the
+/// specified chain index. Uses BIP-340 Schnorr over secp256k1 with the
+/// secret_spending_key as the signing scalar. The message is SHA-256
+/// prehashed (matching the existing nssa::Signature::new convention).
+///
+/// Designed for clients that need to sign application-level material
+/// (e.g. an A2A AgentCard or a JWS) with the same key tree the wallet
+/// uses, without surfacing the private scalar to the host.
+///
+/// # Parameters
+/// - `handle`: Valid wallet handle
+/// - `chain_index_str`: Null-terminated UTF-8 chain index path (e.g. "/" for the root)
+/// - `message`: Pointer to the message bytes to sign
+/// - `message_len`: Length of the message in bytes
+/// - `out_sig`: Output pointer for the {signature, verifying public key} pair
+///
+/// # Returns
+/// - `Success` on success
+/// - `InvalidUtf8` if `chain_index_str` is malformed
+/// - `AccountNotFound` if no node exists at the given chain index
+/// - `InternalError` if the signing scalar is not a valid k256 secret key
+/// - Error code on other failures
+///
+/// # Safety
+/// - `handle` must be a valid wallet handle
+/// - `chain_index_str` must be a valid null-terminated UTF-8 string
+/// - `message` must be a valid pointer to at least `message_len` bytes
+/// - `out_sig` must be a valid pointer to an `FfiCardSignature` struct
+#[no_mangle]
+pub unsafe extern "C" fn wallet_ffi_sign_message_at_chain_index(
+    handle: *mut WalletHandle,
+    chain_index_str: *const std::ffi::c_char,
+    message: *const u8,
+    message_len: usize,
+    out_sig: *mut FfiCardSignature,
+) -> WalletFfiError {
+    use key_protocol::key_management::key_tree::chain_index::ChainIndex;
+    use sha2::{Digest as _, Sha256};
+    use std::str::FromStr as _;
+
+    let wrapper = match get_wallet(handle) {
+        Ok(w) => w,
+        Err(e) => return e,
+    };
+
+    if chain_index_str.is_null() || message.is_null() || out_sig.is_null() {
+        print_error("Null pointer argument");
+        return WalletFfiError::NullPointer;
+    }
+
+    let Ok(chain_index_str) = crate::c_str_to_string(chain_index_str, "chain_index_str") else {
+        return WalletFfiError::InvalidUtf8;
+    };
+    let Ok(chain_index) = ChainIndex::from_str(&chain_index_str) else {
+        print_error(format!("Failed to parse chain index: {chain_index_str}"));
+        return WalletFfiError::InvalidKeyValue;
+    };
+
+    let wallet = match wrapper.core.lock() {
+        Ok(w) => w,
+        Err(e) => {
+            print_error(format!("Failed to lock wallet: {e}"));
+            return WalletFfiError::InternalError;
+        }
+    };
+
+    let Some(key_chain) = wallet.private_accounts_key_chain_by_index(&chain_index) else {
+        print_error(format!("No private accounts key at chain index {chain_index_str}"));
+        return WalletFfiError::AccountNotFound;
+    };
+
+    let secret_scalar = key_chain.secret_spending_key.0;
+    let Ok(signing_key) = k256::schnorr::SigningKey::from_bytes(&secret_scalar) else {
+        print_error("secret_spending_key is not a valid Schnorr signing scalar");
+        return WalletFfiError::InternalError;
+    };
+
+    // Prehash with SHA-256 to fit the 32-byte BIP-340 message input.
+    let msg_slice = unsafe { std::slice::from_raw_parts(message, message_len) };
+    let mut hasher = Sha256::new();
+    hasher.update(msg_slice);
+    let prehash: [u8; 32] = hasher.finalize().into();
+
+    let mut aux_random = [0_u8; 32];
+    use k256::elliptic_curve::rand_core::{OsRng, RngCore as _};
+    OsRng.fill_bytes(&mut aux_random);
+
+    let signature = match signing_key.sign_prehash_with_aux_rand(&prehash, &aux_random) {
+        Ok(s) => s,
+        Err(e) => {
+            print_error(format!("Schnorr signing failed: {e}"));
+            return WalletFfiError::InternalError;
+        }
+    };
+
+    let verifying_key = signing_key.verifying_key();
+    let verifying_bytes = verifying_key.to_bytes();
+
+    unsafe {
+        (*out_sig).signature = signature.to_bytes();
+        (*out_sig).verifying_public_key = verifying_bytes.into();
+    }
+
+    WalletFfiError::Success
+}
+
 /// Free private account keys returned by `wallet_ffi_get_private_account_keys`.
 ///
 /// # Safety

--- a/wallet-ffi/src/lib.rs
+++ b/wallet-ffi/src/lib.rs
@@ -94,7 +94,7 @@ pub(crate) fn map_execution_error(e: ExecutionFailureKind) -> FfiError {
 }
 
 /// Helper to convert a C string to a Rust String.
-fn c_str_to_string(ptr: *const c_char, name: &str) -> Result<String, WalletFfiError> {
+pub(crate) fn c_str_to_string(ptr: *const c_char, name: &str) -> Result<String, WalletFfiError> {
     if ptr.is_null() {
         print_error(format!("Null pointer for {name}"));
         return Err(WalletFfiError::NullPointer);

--- a/wallet-ffi/wallet_ffi.h
+++ b/wallet-ffi/wallet_ffi.h
@@ -507,6 +507,72 @@ enum WalletFfiError wallet_ffi_get_private_account_keys(struct WalletHandle *han
                                                         struct FfiPrivateAccountKeys *out_keys);
 
 /**
+ * Return the keys of the first private accounts key chain in the wallet.
+ *
+ * The first chain is determined by BTreeMap ordering over chain indices,
+ * which is deterministic — calling this function on a wallet persisted to
+ * disk and reopened later returns the same NPK as long as no preceding
+ * chain index was inserted in between.
+ *
+ * Intended for clients (e.g. agent runtimes) that need a stable
+ * cryptographic identity derived from the wallet seed without rotating
+ * it at every call to `wallet_ffi_create_private_accounts_key`.
+ *
+ * # Parameters
+ * - `handle`: Valid wallet handle
+ * - `out_keys`: Output pointer for the key material
+ *
+ * # Returns
+ * - `Success` on success
+ * - `AccountNotFound` if the wallet has no private accounts key yet
+ * - Error code on other failures
+ *
+ * # Memory
+ * The keys must be freed with `wallet_ffi_free_private_account_keys()`.
+ *
+ * # Safety
+ * - `handle` must be a valid wallet handle from `wallet_ffi_create_new` or `wallet_ffi_open`
+ * - `out_keys` must be a valid pointer to a `FfiPrivateAccountKeys` struct
+ */
+enum WalletFfiError wallet_ffi_get_first_private_accounts_key(struct WalletHandle *handle,
+                                                              struct FfiPrivateAccountKeys *out_keys);
+
+/**
+ * Return the keys of the private accounts key node at a specific chain
+ * index. The chain index is given as the wallet-CLI string format,
+ * e.g. "/" for the root node, "/0" for the first child, "/0/1" for a
+ * nested node, etc.
+ *
+ * Intended for clients that need a stable cryptographic identity
+ * anchored on a known position in the key tree. Combined with the root
+ * node "/" seeded automatically by `WalletCore::new_init_storage`, this
+ * gives a deterministic agent identity that survives wallet reopen
+ * without any side-car cache.
+ *
+ * # Parameters
+ * - `handle`: Valid wallet handle
+ * - `chain_index_str`: Null-terminated UTF-8 chain index path
+ * - `out_keys`: Output pointer for the key material
+ *
+ * # Returns
+ * - `Success` on success
+ * - `InvalidUtf8` if `chain_index_str` is malformed
+ * - `AccountNotFound` if no node exists at the given chain index
+ * - Error code on other failures
+ *
+ * # Memory
+ * The keys must be freed with `wallet_ffi_free_private_account_keys()`.
+ *
+ * # Safety
+ * - `handle` must be a valid wallet handle from `wallet_ffi_create_new` or `wallet_ffi_open`
+ * - `chain_index_str` must be a valid null-terminated UTF-8 string
+ * - `out_keys` must be a valid pointer to a `FfiPrivateAccountKeys` struct
+ */
+enum WalletFfiError wallet_ffi_get_private_accounts_key_by_chain_index(struct WalletHandle *handle,
+                                                                       const char *chain_index_str,
+                                                                       struct FfiPrivateAccountKeys *out_keys);
+
+/**
  * Free private account keys returned by `wallet_ffi_get_private_account_keys`.
  *
  * # Safety

--- a/wallet-ffi/wallet_ffi.h
+++ b/wallet-ffi/wallet_ffi.h
@@ -208,6 +208,19 @@ typedef struct FfiPublicAccountKey {
 } FfiPublicAccountKey;
 
 /**
+ * FFI signature shape produced by `wallet_ffi_sign_message_at_chain_index`.
+ *
+ * `signature` is a 64-byte BIP-340 Schnorr-over-secp256k1 signature.
+ * `verifying_public_key` is the 32-byte x-only public key matching the
+ * signing key derived at the specified chain index. Both arrays are
+ * inlined by value — no allocation, no free function needed.
+ */
+typedef struct FfiCardSignature {
+  uint8_t signature[64];
+  uint8_t verifying_public_key[32];
+} FfiCardSignature;
+
+/**
  * Result of a transfer operation.
  */
 typedef struct FfiTransferResult {
@@ -571,6 +584,42 @@ enum WalletFfiError wallet_ffi_get_first_private_accounts_key(struct WalletHandl
 enum WalletFfiError wallet_ffi_get_private_accounts_key_by_chain_index(struct WalletHandle *handle,
                                                                        const char *chain_index_str,
                                                                        struct FfiPrivateAccountKeys *out_keys);
+
+/**
+ * Sign an arbitrary message with the private accounts key at the
+ * specified chain index. Uses BIP-340 Schnorr over secp256k1 with the
+ * secret_spending_key as the signing scalar. The message is SHA-256
+ * prehashed (matching the existing nssa::Signature::new convention).
+ *
+ * Designed for clients that need to sign application-level material
+ * (e.g. an A2A AgentCard or a JWS) with the same key tree the wallet
+ * uses, without surfacing the private scalar to the host.
+ *
+ * # Parameters
+ * - `handle`: Valid wallet handle
+ * - `chain_index_str`: Null-terminated UTF-8 chain index path (e.g. "/" for the root)
+ * - `message`: Pointer to the message bytes to sign
+ * - `message_len`: Length of the message in bytes
+ * - `out_sig`: Output pointer for the {signature, verifying public key} pair
+ *
+ * # Returns
+ * - `Success` on success
+ * - `InvalidUtf8` if `chain_index_str` is malformed
+ * - `AccountNotFound` if no node exists at the given chain index
+ * - `InternalError` if the signing scalar is not a valid k256 secret key
+ * - Error code on other failures
+ *
+ * # Safety
+ * - `handle` must be a valid wallet handle
+ * - `chain_index_str` must be a valid null-terminated UTF-8 string
+ * - `message` must be a valid pointer to at least `message_len` bytes
+ * - `out_sig` must be a valid pointer to an `FfiCardSignature` struct
+ */
+enum WalletFfiError wallet_ffi_sign_message_at_chain_index(struct WalletHandle *handle,
+                                                           const char *chain_index_str,
+                                                           const uint8_t *message,
+                                                           uintptr_t message_len,
+                                                           struct FfiCardSignature *out_sig);
 
 /**
  * Free private account keys returned by `wallet_ffi_get_private_account_keys`.

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -13,7 +13,7 @@ use anyhow::{Context as _, Result};
 use bip39::Mnemonic;
 use common::{HashType, transaction::NSSATransaction};
 use config::WalletConfig;
-use key_protocol::key_management::key_tree::chain_index::ChainIndex;
+use key_protocol::key_management::{KeyChain, key_tree::chain_index::ChainIndex};
 use log::info;
 use nssa::{
     Account, AccountId, PrivacyPreservingTransaction,
@@ -246,6 +246,34 @@ impl WalletCore {
         self.storage
             .key_chain_mut()
             .create_private_accounts_key(chain_index)
+    }
+
+    /// Return the KeyChain of the first private accounts key in the wallet.
+    /// BTreeMap iteration over chain indices is deterministic, so this is
+    /// stable across wallet reopens for the same persisted storage. Used by
+    /// clients (e.g. agent runtimes) that need a stable cryptographic
+    /// identity tied to the wallet seed without rotating it at every
+    /// create_private_accounts_key call.
+    #[must_use]
+    pub fn first_private_accounts_key_chain(&self) -> Option<&KeyChain> {
+        self.storage
+            .key_chain()
+            .private_account_key_chains()
+            .next()
+            .map(|(_account_id, key_chain, _chain_index)| key_chain)
+    }
+
+    /// Return the KeyChain of the private accounts key at the given chain
+    /// index. Lets clients persist a pointer (chain_index, not crypto) and
+    /// look the same key back up across restarts deterministically.
+    #[must_use]
+    pub fn private_accounts_key_chain_by_index(
+        &self,
+        chain_index: &ChainIndex,
+    ) -> Option<&KeyChain> {
+        self.storage
+            .key_chain()
+            .private_account_key_chain_by_index(chain_index)
     }
 
     pub fn create_new_account_private(


### PR DESCRIPTION
## Summary

Adds two `wallet-ffi` entries (and matching `WalletCore` accessors) that let a client resolve a stable cryptographic identity from a persisted wallet without rotating it at every restart.

- `wallet_ffi_get_first_private_accounts_key(handle, out_keys)` — returns the first private accounts key in the wallet (BTreeMap-ordered, deterministic across reopens for the same persisted storage).
- `wallet_ffi_get_private_accounts_key_by_chain_index(handle, chain_index_str, out_keys)` — returns the private accounts key at an explicit chain index using the wallet-CLI string format (`/`, `/0`, `/0/1`, …).

Purely additive; no behaviour change for existing callers.

## Why

Currently, `wallet-ffi` exposes:

- `wallet_ffi_create_private_accounts_key` — derives a **new** chain at the next free layered index each time it is called, rotating the NPK at every call.
- `wallet_ffi_get_private_account_keys(account_id)` — returns a **sub-account** key chain (the per-account NPK derived under a parent), not the parent chain master.

Neither lets a downstream application restore the **same agent-level NPK** after a wallet reopen. The workaround today is to cache the NPK in a sidecar file at the application layer, which is fragile and couples the application to file-layout assumptions that live outside the wallet.

The new accessors close that gap: by anchoring identity on a known chain index (`"/"` for the seed-root node) the application gets a deterministic identity for the lifetime of the wallet seed.

## Motivation

I am building an [LP-0008 (autonomous AI module)](https://github.com/logos-co/lambda-prize/blob/main/prizes/LP-0008.md) submission. Agent identity is the agent's NPK; without this patch, the agent's identity rotates every time Basecamp restarts the host process, breaking AgentCards announced to peers, owner-channel routing, and demo reproducibility.

## Implementation

- `wallet/src/lib.rs`: two new accessors on `WalletCore`. They thin-wrap existing `UserKeyChain::private_account_key_chains` (BTreeMap iter, deterministic) and `UserKeyChain::private_account_key_chain_by_index`.
- `wallet-ffi/src/keys.rs`: matching FFI entry points. They use the same `FfiPrivateAccountKeys` out-shape and lifetime management as the existing `wallet_ffi_get_private_account_keys`.
- `wallet-ffi/src/lib.rs`: bump `c_str_to_string` visibility to `pub(crate)` so the new entry can reuse it.
- `wallet-ffi/wallet_ffi.h`: regenerated by cbindgen as part of the wallet-ffi build.

## Test plan

- [x] `cargo build --release -p wallet-ffi --no-default-features` (used downstream in the agent module).
- [x] Symbol present in the built dylib: `nm libwallet_ffi.dylib | grep wallet_ffi_get_private_accounts_key_by_chain_index`.
- [x] Manual round-trip from the agent module: persisted wallet reopened across module restarts returns the identical NPK via the `"/"` lookup. Verified with NPK `40b5854e7b498cdf91461ed66da64df23e1a47389f752f4f392a5d19c3218371`.
- [ ] Unit tests for the new accessors (happy to add if reviewers want them; existing `wallet-ffi` crate does not have an integration test bench I could plug into directly).

## Notes

The header file changes are mechanical (cbindgen output). The visibility bump on `c_str_to_string` is the minimal change needed to reuse the existing helper; happy to inline a private copy instead if the reviewer prefers.