### PR TITLE
Persist wallet sync progress at checkpoints

### DIFF
--- a/lez/wallet/src/lib.rs
+++ b/lez/wallet/src/lib.rs
@@ -50,6 +50,32 @@ pub mod storage;
 
 pub const HOME_DIR_ENV_VAR: &str = "LEE_WALLET_HOME_DIR";
 
+const SYNC_PERSIST_CHECKPOINT_BLOCKS: usize = 100;
+
+#[derive(Default)]
+struct SyncPersistenceCheckpoint {
+    blocks_since_last_persist: usize,
+}
+
+impl SyncPersistenceCheckpoint {
+    const fn record_block(&mut self) -> bool {
+        self.blocks_since_last_persist = self
+            .blocks_since_last_persist
+            .checked_add(1)
+            .expect("checkpoint counter is reset before overflow");
+        if self.blocks_since_last_persist < SYNC_PERSIST_CHECKPOINT_BLOCKS {
+            return false;
+        }
+
+        self.blocks_since_last_persist = 0;
+        true
+    }
+
+    const fn needs_final_persist(&self) -> bool {
+        self.blocks_since_last_persist > 0
+    }
+}
+
 pub enum AccDecodeData {
     Skip,
     Decode(lee_core::SharedSecretKey, AccountId),
@@ -720,6 +746,7 @@ impl WalletCore {
         // Get the latest nullifiers for all owned accounts.
         let mut index = self.storage.key_chain().build_latest_nullifier_index();
         let bar = indicatif::ProgressBar::new(num_of_blocks);
+        let mut checkpoint = SyncPersistenceCheckpoint::default();
         while let Some(block) = blocks.try_next().await? {
             for tx in block.body.transactions {
                 let LeeTransaction::PrivacyPreserving(pp_tx) = &tx else {
@@ -735,8 +762,16 @@ impl WalletCore {
             }
 
             self.storage.set_last_synced_block(block.header.block_id);
-            self.store_persistent_data()?;
+            // Keep the account state and its watermark durable together. If syncing
+            // fails or is cancelled between checkpoints, reopening replays only the
+            // unpersisted tail instead of trusting a partial update.
+            if checkpoint.record_block() {
+                self.store_persistent_data()?;
+            }
             bar.inc(1);
+        }
+        if checkpoint.needs_final_persist() {
+            self.store_persistent_data()?;
         }
         bar.finish();
 
@@ -899,6 +934,8 @@ mod tests {
 
     use bip39::Mnemonic;
 
+    use super::SyncPersistenceCheckpoint;
+
     #[test]
     fn mnemonic_roundtrip() {
         let mnemonic =
@@ -913,5 +950,20 @@ mod tests {
         let mn_ret = Mnemonic::from_str(mn_string).unwrap();
 
         assert_eq!(mnemonic, mn_ret);
+    }
+
+    #[test]
+    fn sync_persistence_checkpoints_full_chunks_and_final_tail() {
+        let mut checkpoint = SyncPersistenceCheckpoint::default();
+        let mut persisted_after = Vec::new();
+
+        for block in 1..=201 {
+            if checkpoint.record_block() {
+                persisted_after.push(block);
+            }
+        }
+
+        assert_eq!(persisted_after, vec![100, 200]);
+        assert!(checkpoint.needs_final_persist());
     }
 }


### PR DESCRIPTION
## 🎯 Purpose

`WalletCore::sync_to_block` currently persists the complete wallet storage after
every processed block. A wallet catching up over a large range therefore
performs one full local storage write per block, creating unnecessary disk I/O
and serialization work for every consumer of the wallet core.

Fixes #631 

## ⚙️ Approach

- Add a local checkpoint counter to block synchronization.
- Persist after every 100 successfully processed blocks.
- Persist any remaining tail before a successful sync returns.
- Keep account state and the `last_synced_block` watermark in the existing
  single persistence operation. If sync is interrupted between checkpoints,
  reopening resumes from the last durable checkpoint and replays only the
  unpersisted tail.
- Leave explicit lifecycle saves unchanged.

No wallet storage format, protocol behavior, or FFI/API surface changes.

## 🧪 How to Test

```bash
cargo +nightly fmt --all -- --check
cargo +1.94.0 test -p wallet --lib
RISC0_SKIP_BUILD=1 cargo +1.94.0 clippy -p wallet --lib --all-features -- -D warnings
```

All passed. The wallet unit suite includes coverage for full checkpoint chunks
and a final partial tail.

## 🔗 Dependencies

None.

## 🔜 Future Work

None.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments