### PR TITLE
feat(lee): program pubtx - batch a Deploy's bytecode across multiple transactions

### DIFF
--- a/integration_tests/src/utils.rs
+++ b/integration_tests/src/utils.rs
@@ -358,6 +358,9 @@ pub fn deploy_transaction(
     // helper itself panicking before the real system ever sees it.
     let user_elf =
         program_loader_core::extract_user_elf(bytecode).unwrap_or_else(|_| bytecode.to_vec());
+    // Falls back to a dummy image_id for deliberately-garbage bytecode too — execute_deploy's own
+    // rejection path is what such tests exercise, not this helper.
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap_or([0; 8]);
     let mut account_ids = vec![header];
     account_ids.extend_from_slice(segments);
     let message = lee::public_transaction::Message::try_new(
@@ -365,6 +368,9 @@ pub fn deploy_transaction(
         account_ids,
         vec![],
         program_loader_core::Instruction::Deploy {
+            image_id,
+            segment_count: u32::try_from(segments.len()).expect("segment count fits in u32"),
+            first_segment: 0,
             update_auth: AccountId::default(),
         },
     )

--- a/lee/state_machine/core/src/program/mod.rs
+++ b/lee/state_machine/core/src/program/mod.rs
@@ -63,6 +63,13 @@ pub struct ProgramData {
     pub image_id: ProgramId,
     /// How many bytecode segment accounts follow, so a reader knows how many to fetch without
     /// probing (see `program_loader_core::segment_account_id`).
+    ///
+    /// Caller-declared on every `Deploy` transaction (a transaction covering only part of the
+    /// program can't derive it from its own fragment), so this is only trustworthy once
+    /// `V03State::get_program` has cross-checked every segment's bytes actually reconstruct to
+    /// `image_id` — not something a single transaction's own execution verifies for a partial
+    /// batch. See `program_loader_core::execute_deploy` for exactly what is and isn't checked
+    /// when.
     pub segment_count: u32,
     pub update_auth: AccountId,
 }

--- a/lee/state_machine/core/src/program/mod.rs
+++ b/lee/state_machine/core/src/program/mod.rs
@@ -67,6 +67,13 @@ pub struct ProgramData {
     pub image_id: ProgramId,
     /// How many bytecode segment accounts follow, so a reader knows how many to fetch without
     /// probing (see `program_loader_core::deploy_segment_account_id`).
+    ///
+    /// Caller-declared on every `Deploy` transaction (a transaction covering only part of the
+    /// program can't derive it from its own fragment), so this is only trustworthy once
+    /// `V03State::get_program` has cross-checked every segment's bytes actually reconstruct to
+    /// `image_id` — not something a single transaction's own execution verifies for a partial
+    /// batch. See `program_loader_core::execute_deploy` for exactly what is and isn't checked
+    /// when.
     pub segment_count: u32,
     pub update_auth: AccountId,
 }

--- a/lee/state_machine/src/state/mod.rs
+++ b/lee/state_machine/src/state/mod.rs
@@ -336,10 +336,14 @@ impl V03State {
     ///
     /// An account that matches neither owner isn't a deployed program, whatever its contents —
     /// this is the single place that distinction is enforced, so callers never have to remember
-    /// to re-check it themselves. `Ok(None)` means no such program exists (missing account or
-    /// segment); `Err(LeeError::InvalidProgramBytecode(_))` means one exists but its segments
-    /// don't reconstruct to the `image_id` its own header declares — a defense-in-depth check
-    /// against a corrupted or malformed segment set, distinguishable from plain absence.
+    /// to re-check it themselves. `Ok(None)` means no such program exists — including, ordinarily,
+    /// a multi-transaction `Deploy` sequence that hasn't (yet, or ever going to) land every one of
+    /// its `segment_count` segments; a caller mid-sequence sees exactly the same result as a
+    /// program that was never deployed at all, by construction, since a missing segment is
+    /// detected the same way regardless of cause. `Err(LeeError::InvalidProgramBytecode(_))` means
+    /// every segment exists but they don't reconstruct to the `image_id` the header declares — a
+    /// defense-in-depth check against a corrupted or malformed segment set, distinguishable from
+    /// plain absence.
     pub fn get_program(
         &self,
         program_account_id: AccountId,

--- a/lee/state_machine/src/state/mod.rs
+++ b/lee/state_machine/src/state/mod.rs
@@ -327,9 +327,13 @@ impl V03State {
     ///
     /// An account not owned by [`PROGRAM_LOADER_ACCOUNT_ID`] isn't a deployed program, whatever
     /// its contents — this is the single place that distinction is enforced, so callers never
-    /// have to remember to re-check it themselves. `Ok(None)` means no such program exists
-    /// (missing account or segment); `Err(LeeError::InvalidProgramBytecode(_))` means one exists
-    /// but its segments don't reconstruct to the `image_id` its own header declares — a
+    /// have to remember to re-check it themselves. `Ok(None)` means no such program exists —
+    /// including, ordinarily, a multi-transaction `Deploy` sequence that hasn't (yet, or ever
+    /// going to) land every one of its `segment_count` segments; a caller mid-sequence sees
+    /// exactly the same result as a program that was never deployed at all, by construction,
+    /// since a missing segment is detected the same way regardless of cause.
+    /// `Err(LeeError::InvalidProgramBytecode(_))` means every segment exists but they don't
+    /// reconstruct to the `image_id` the header declares — a
     /// defense-in-depth check against a corrupted or malformed segment set, distinguishable from
     /// plain absence.
     pub fn get_program(

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -128,10 +128,14 @@ impl ValidatedStateDiff {
                 // like every guest program in this codebase, relying here on `catch_unwind` to
                 // play the same role the zkVM executor plays for a real guest: converting a
                 // rejected input into a graceful `Err` instead of unwinding past this call.
-                let program_loader_core::Instruction::Deploy { update_auth } =
-                    risc0_zkvm::serde::from_slice(&chained_call.instruction_data).map_err(|e| {
-                        LeeError::InvalidInput(format!("invalid Deploy instruction: {e}"))
-                    })?;
+                let program_loader_core::Instruction::Deploy {
+                    image_id,
+                    segment_count,
+                    first_segment,
+                    update_auth,
+                } = risc0_zkvm::serde::from_slice(&chained_call.instruction_data).map_err(|e| {
+                    LeeError::InvalidInput(format!("invalid Deploy instruction: {e}"))
+                })?;
                 // The bytecode itself travels via the transaction's own `raw_payload`, not
                 // `instruction_data` and not `chained_call.raw_payload` (which no guest can ever
                 // set) — see `Message::raw_payload`'s doc comment for why. Deploy only ever runs
@@ -146,6 +150,9 @@ impl ValidatedStateDiff {
                         chained_call.program_account_id,
                         &chained_call.pre_states,
                         &bytecode,
+                        image_id,
+                        segment_count,
+                        first_segment,
                         update_auth,
                     )
                 })

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -127,10 +127,14 @@ impl ValidatedStateDiff {
                 // like every guest program in this codebase, relying here on `catch_unwind` to
                 // play the same role the zkVM executor plays for a real guest: converting a
                 // rejected input into a graceful `Err` instead of unwinding past this call.
-                let program_loader_core::Instruction::Deploy { update_auth } =
-                    borsh::from_slice(&chained_call.instruction_data).map_err(|e| {
-                        LeeError::InvalidInput(format!("invalid Deploy instruction: {e}"))
-                    })?;
+                let program_loader_core::Instruction::Deploy {
+                    image_id,
+                    segment_count,
+                    first_segment,
+                    update_auth,
+                } = borsh::from_slice(&chained_call.instruction_data).map_err(|e| {
+                    LeeError::InvalidInput(format!("invalid Deploy instruction: {e}"))
+                })?;
                 // The bytecode itself travels via the transaction's own `raw_payload`, not
                 // `instruction_data` and not `chained_call.raw_payload` (which no guest can ever
                 // set) — see `Message::raw_payload`'s doc comment for why. Deploy only ever runs
@@ -145,6 +149,9 @@ impl ValidatedStateDiff {
                         chained_call.program_account_id,
                         &chained_call.pre_states,
                         &bytecode,
+                        image_id,
+                        segment_count,
+                        first_segment,
                         update_auth,
                     )
                 })

--- a/lez/programs/program_loader/core/src/lib.rs
+++ b/lez/programs/program_loader/core/src/lib.rs
@@ -1,7 +1,7 @@
 pub use lee_core::program::{PdaSeed, ProgramData};
 use lee_core::{
     account::{Account, AccountId, AccountWithMetadata, Data},
-    program::{AccountPostState, Claim, ProgramId},
+    program::{AccountPostState, Claim, DEFAULT_PROGRAM_OWNER, ProgramId},
 };
 use serde::{Deserialize, Serialize};
 
@@ -28,23 +28,41 @@ pub const MAX_SEGMENT_DATA_LEN: usize = 96 * 1024;
 
 #[derive(Serialize, Deserialize)]
 pub enum Instruction {
-    /// Deploys a new program: writes its `ProgramData` header and as many bytecode segments as
-    /// its size requires (see [`MAX_SEGMENT_DATA_LEN`]), each claimed as a PDA of the loader.
+    /// Deploys a program, in whole or in part: writes its `ProgramData` header and the bytecode
+    /// segments this transaction's `raw_payload` covers, each claimed as a PDA of the loader.
+    /// One or more `Deploy`s (each covering a contiguous range of segments) complete a
+    /// deployment — see [`execute_deploy`] for exactly what each transaction requires.
     ///
     /// The bytecode itself travels via the dispatching message's `raw_payload`, not this
     /// instruction — see `Message::raw_payload`'s doc comment for why.
     ///
-    /// Required accounts (1 + `segment_count`, where `segment_count` is determined by the
-    /// submitted bytecode's length — see [`plan_deploy`]), in order:
-    /// - The target `ProgramData` header PDA account (must be `Account::default()`)
-    /// - The target segment PDA accounts holding the raw bytecode, in segment order (each must be
-    ///   `Account::default()`)
+    /// Required accounts, in order:
+    /// - The target `ProgramData` header PDA account (must be `Account::default()`, or already
+    ///   exactly this deployment's header — see [`execute_deploy`])
+    /// - If this transaction doesn't deliver the whole program in one shot: an account matching
+    ///   `update_auth`, signed (`is_authorized`) by its holder
+    /// - The target segment PDA accounts this transaction covers (`first_segment,
+    ///   first_segment+1, ...`), in order (each must be `Account::default()`)
     Deploy {
+        /// Caller-declared identity of the program being deployed. Verified immediately against
+        /// the real bytecode when a transaction delivers the whole program in one shot;
+        /// otherwise verified lazily by `V03State::get_program` once every segment exists — see
+        /// [`execute_deploy`].
+        image_id: ProgramId,
+        /// Total segment count for the whole deployment. Caller-declared for the same reason as
+        /// `image_id`: a transaction covering only part of the program can't derive it from its
+        /// own fragment. Must be identical across every transaction in one deployment.
+        segment_count: u32,
+        /// `segment_number` of this transaction's first segment (0-indexed); its remaining
+        /// segment accounts are `first_segment, first_segment+1, ...` in order.
+        first_segment: u32,
         /// Distinguishes independent deployments of identical bytecode (same `image_id`) from
         /// one another, so a second deployer never collides with an existing deployment's PDAs.
-        /// Also who may redeploy this same slot in the future once upgrade authority is
-        /// implemented (a future PR) — for now this is a placeholder with no enforcement.
-        /// `AccountId::default()` means no upgrade authority (immutable).
+        /// Also who may redeploy this same slot in the future once upgrade authority is fully
+        /// implemented (a future PR), and — already enforced now — who must sign any transaction
+        /// that can't verify itself immediately (see [`execute_deploy`]). `AccountId::default()`
+        /// means no upgrade authority (immutable); such a program can only be deployed in a
+        /// single, self-contained transaction, since there's no key to sign a partial one with.
         update_auth: AccountId,
     },
 }
@@ -191,26 +209,29 @@ pub fn deploy_segment_account_id(
     )
 }
 
-/// Computes the account shape (header + N bytecode segments, chunked at
-/// [`MAX_SEGMENT_DATA_LEN`]) for deploying `user_elf` at `image_id` under `update_auth`.
+/// Plans the account shape for one batch of a (possibly multi-transaction) deploy.
 ///
-/// The single source of truth both [`execute_deploy`] and `V03State::insert_program` build from —
-/// so live deploys and genesis-seeded programs can never diverge on chunk boundaries, ordering,
-/// or PDA derivation.
+/// Builds the header (unchanged formula — always `segment_number` 0, independent of
+/// `segment_count`, so [`immutable_deploy_account_id`] stays stable regardless of how a deploy is
+/// batched) plus `batch_user_elf` chunked at [`MAX_SEGMENT_DATA_LEN`], numbered `first_segment,
+/// first_segment+1, ...`.
+///
+/// `segment_count` is the *total* across the whole deployment, not just this batch — written
+/// into the header's `ProgramData` identically by every batch, so [`execute_deploy`]'s header
+/// check can catch a caller who declares a different total between transactions. [`plan_deploy`]
+/// is the single-batch (whole program, `first_segment` 0) special case of this — the single
+/// source of truth both [`execute_deploy`] and `V03State::insert_program` build from, so live
+/// deploys and genesis-seeded programs can never diverge on chunk boundaries, ordering, or PDA
+/// derivation.
 #[must_use]
-pub fn plan_deploy(
+pub fn plan_deploy_range(
     loader_account_id: AccountId,
     image_id: ProgramId,
+    segment_count: u32,
     update_auth: AccountId,
-    user_elf: &[u8],
+    first_segment: u32,
+    batch_user_elf: &[u8],
 ) -> DeployPlan {
-    let chunks: Vec<&[u8]> = if user_elf.is_empty() {
-        vec![&[]]
-    } else {
-        user_elf.chunks(MAX_SEGMENT_DATA_LEN).collect()
-    };
-    let segment_count = u32::try_from(chunks.len()).expect("segment count fits in u32");
-
     let header_seed = deploy_header_pda_seed(image_id, 0, update_auth);
     let header = PlannedAccount {
         account_id: AccountId::for_public_pda(&loader_account_id, &header_seed),
@@ -223,11 +244,23 @@ pub fn plan_deploy(
         .expect("ProgramData borsh serialization should not fail"),
     };
 
+    // An empty program still needs exactly one (empty) segment to exist — but only when this
+    // batch is the whole thing; an empty *partial* batch is a caller error execute_deploy's own
+    // non-empty-batch assertion rejects, not something to paper over here.
+    let chunks: Vec<&[u8]> =
+        if batch_user_elf.is_empty() && first_segment == 0 && segment_count <= 1 {
+            vec![&[]]
+        } else {
+            batch_user_elf.chunks(MAX_SEGMENT_DATA_LEN).collect()
+        };
+
     let segments = chunks
         .into_iter()
         .enumerate()
         .map(|(i, chunk)| {
-            let segment_number = u32::try_from(i).expect("segment index fits in u32");
+            let segment_number = first_segment
+                .checked_add(u32::try_from(i).expect("segment index fits in u32"))
+                .expect("segment number fits in u32");
             let seed = deploy_segment_pda_seed(image_id, segment_number, update_auth);
             PlannedAccount {
                 account_id: AccountId::for_public_pda(&loader_account_id, &seed),
@@ -238,6 +271,40 @@ pub fn plan_deploy(
         .collect();
 
     DeployPlan { header, segments }
+}
+
+/// Computes the account shape (header + N bytecode segments) for deploying the whole of
+/// `user_elf` at `image_id` under `update_auth` in a single batch. See [`plan_deploy_range`].
+#[must_use]
+pub fn plan_deploy(
+    loader_account_id: AccountId,
+    image_id: ProgramId,
+    update_auth: AccountId,
+    user_elf: &[u8],
+) -> DeployPlan {
+    let segment_count = segment_count_for(user_elf);
+    plan_deploy_range(
+        loader_account_id,
+        image_id,
+        segment_count,
+        update_auth,
+        0,
+        user_elf,
+    )
+}
+
+/// Computes the total segment count deploying `user_elf` would require.
+///
+/// At [`MAX_SEGMENT_DATA_LEN`], without building the full plan — what the first transaction of a
+/// multi-transaction deploy needs to declare before the whole program exists on chain.
+#[must_use]
+pub fn segment_count_for(user_elf: &[u8]) -> u32 {
+    let n = if user_elf.is_empty() {
+        1
+    } else {
+        user_elf.len().div_ceil(MAX_SEGMENT_DATA_LEN)
+    };
+    u32::try_from(n).expect("segment count fits in u32")
 }
 
 /// The dispatch address a program with `image_id` lives at once deployed via `Deploy` with no
@@ -255,44 +322,148 @@ pub fn immutable_deploy_account_id(image_id: ProgramId) -> AccountId {
     )
 }
 
-/// Executes the `Deploy` instruction.
+/// Executes one `Deploy` transaction — either a whole deployment in one shot, or one batch of a
+/// multi-transaction deployment.
 ///
-/// Verifies `user_elf` decodes as a valid RISC0 program (with the assumed [`KERNEL_ELF`]),
-/// derives its header and segment PDAs via [`plan_deploy`], and claims all of them. Called
-/// natively from dispatch's `RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID` shortcut (see that
+/// `image_id`/`segment_count` are caller-declared, not derived from `user_elf_batch` (a batch
+/// covering only part of the program can't derive either from its own fragment). Whether that
+/// declaration is trustworthy going into this call, and consequently what this transaction must
+/// additionally prove, depends on whether `first_segment == 0` and `user_elf_batch` covers all
+/// `segment_count` segments — i.e. whether this transaction is the whole deployment:
+///
+/// - **Whole deployment in one shot**: `user_elf_batch` is independently decoded and its real
+///   `image_id` recomputed (combined with the assumed [`KERNEL_ELF`]) and checked against the
+///   declared one right here — exactly as trustworthy as a single-transaction deploy, no
+///   signature required.
+/// - **A genuine partial batch**: `image_id`/`segment_count` can't be verified from what this
+///   transaction alone carries — [`V03State::get_program`] only catches a mismatch once every
+///   segment eventually exists. In the meantime, this transaction must instead prove control of
+///   `update_auth`: `update_auth` must be non-default (there is no key to sign a partial deploy
+///   of an immutable program with), included as this call's second `pre_states` entry, and
+///   `is_authorized`. Every transaction in a partial sequence re-proves this independently, so no
+///   one else can inject a rogue continuation into someone else's in-progress deployment either.
+///
+/// Derives the header and this batch's segment PDAs (chunking `user_elf_batch` across as many
+/// segments as it covers, starting at `first_segment` — see [`plan_deploy_range`]) and claims
+/// all of them. The header target may be `Account::default()` (starting a new deployment) or
+/// already exactly this deployment's header (continuing one) — every other target must be
+/// `Account::default()`, since each segment is written exactly once.
+///
+/// Called natively from dispatch's `RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID` shortcut (see that
 /// constant's doc comment in `lee_core::program`) — `Deploy` has no guest binary of its own.
 #[must_use]
 pub fn execute_deploy(
     self_account_id: AccountId,
     pre_states: &[AccountWithMetadata],
-    user_elf: &[u8],
+    user_elf_batch: &[u8],
+    image_id: ProgramId,
+    segment_count: u32,
+    first_segment: u32,
     update_auth: AccountId,
 ) -> Vec<AccountPostState> {
-    let image_id =
-        compute_image_id(user_elf).expect("user_elf must decode as a valid RISC0 program binary");
-    let plan = plan_deploy(self_account_id, image_id, update_auth, user_elf);
-
-    let expected_len = plan
-        .segments
-        .len()
-        .checked_add(1)
-        .expect("segment count fits in usize");
-    assert_eq!(
-        pre_states.len(),
-        expected_len,
-        "Deploy requires exactly 1 header + segment_count segment accounts"
+    let plan = plan_deploy_range(
+        self_account_id,
+        image_id,
+        segment_count,
+        update_auth,
+        first_segment,
+        user_elf_batch,
     );
-    let (header_target, segment_targets) =
-        pre_states.split_first().expect("checked non-empty above");
+    let batch_end = first_segment
+        .checked_add(u32::try_from(plan.segments.len()).expect("segment count fits in u32"))
+        .expect("no overflow");
+    assert!(
+        batch_end <= segment_count,
+        "Deploy batch runs past the declared segment_count"
+    );
+    let is_complete = first_segment == 0 && batch_end == segment_count;
 
-    check_deploy_target(header_target, &plan.header);
+    let (header_target, update_auth_target, segment_targets) = if is_complete {
+        let real_image_id = compute_image_id(user_elf_batch)
+            .expect("user_elf must decode as a valid RISC0 program binary");
+        assert_eq!(
+            image_id, real_image_id,
+            "declared image_id does not match the submitted bytecode"
+        );
+        let (header_target, segment_targets) = pre_states
+            .split_first()
+            .expect("Deploy requires at least a header account");
+        (header_target, None, segment_targets)
+    } else {
+        assert_ne!(
+            update_auth,
+            AccountId::default(),
+            "a partial Deploy requires a real update_auth - an immutable program can only be \
+             deployed in a single, self-contained transaction"
+        );
+        let (header_target, rest) = pre_states
+            .split_first()
+            .expect("Deploy requires at least a header account");
+        let (update_auth_target, segment_targets) = rest
+            .split_first()
+            .expect("a partial Deploy requires an update_auth signer account after the header");
+        assert_eq!(
+            update_auth_target.account_id, update_auth,
+            "second account of a partial Deploy must be the update_auth account"
+        );
+        assert!(
+            update_auth_target.is_authorized,
+            "a partial Deploy requires update_auth's signature"
+        );
+        (header_target, Some(update_auth_target), segment_targets)
+    };
+
+    assert!(
+        !plan.segments.is_empty(),
+        "Deploy batch must include at least one segment"
+    );
+    assert_eq!(
+        segment_targets.len(),
+        plan.segments.len(),
+        "Deploy requires exactly one target account per segment in this batch"
+    );
+
+    check_header_target(self_account_id, header_target, &plan.header);
     for (target, planned) in segment_targets.iter().zip(&plan.segments) {
-        check_deploy_target(target, planned);
+        check_segment_target(target, planned);
     }
 
-    std::iter::once(&plan.header)
-        .chain(&plan.segments)
-        .map(|planned| {
+    // pre_states/post_states are matched positionally (see validate_execution), so an
+    // update_auth signer slot present in pre_states must get a matching entry here too. Its
+    // nonce gets bumped just by signing (independent of this program), so once it's ever
+    // acted as a signer it's no longer `Account::default()` — left unclaimed, that combination
+    // (non-default account, default owner) is permanently rejected by validate_execution on any
+    // later batch that reuses it. Claiming it under the loader on its first use avoids that;
+    // later batches then see it already loader-owned and just pass it through unchanged.
+    let update_auth_post_state = update_auth_target.map(|target| {
+        if target.account.program_owner == DEFAULT_PROGRAM_OWNER {
+            AccountPostState::new_claimed(target.account.clone(), Claim::Authorized)
+        } else {
+            AccountPostState::new(target.account.clone())
+        }
+    });
+
+    // A fresh header claims default->owned via Claim::Pda, same as -7. An idempotent re-claim
+    // (a later batch in the same sequence revisiting the header) must mirror the pre-state
+    // exactly instead — validate_execution rejects any post-state whose program_owner differs
+    // from pre, and the header's real program_owner is already set from the earlier batch's
+    // claim by this point, not the default placeholder a fresh claim's post-state carries.
+    let header_post_state = if header_target.account == Account::default() {
+        AccountPostState::new_claimed(
+            Account {
+                data: Data::try_from(plan.header.data.clone())
+                    .expect("elf chunk must fit under DATA_MAX_LENGTH"),
+                ..Account::default()
+            },
+            Claim::Pda(plan.header.seed),
+        )
+    } else {
+        AccountPostState::new(header_target.account.clone())
+    };
+
+    std::iter::once(header_post_state)
+        .chain(update_auth_post_state)
+        .chain(plan.segments.iter().map(|planned| {
             AccountPostState::new_claimed(
                 Account {
                     data: Data::try_from(planned.data.clone())
@@ -301,11 +472,36 @@ pub fn execute_deploy(
                 },
                 Claim::Pda(planned.seed),
             )
-        })
+        }))
         .collect()
 }
 
-fn check_deploy_target(target: &AccountWithMetadata, planned: &PlannedAccount) {
+/// The header may either be a fresh claim (`Account::default()`) or an idempotent re-claim of
+/// exactly this deployment's already-written header — never anything else.
+fn check_header_target(
+    self_account_id: AccountId,
+    target: &AccountWithMetadata,
+    planned: &PlannedAccount,
+) {
+    assert_eq!(
+        target.account_id, planned.account_id,
+        "wrong deployment target account"
+    );
+    let already_this_header = Account {
+        program_owner: self_account_id,
+        data: Data::try_from(planned.data.clone())
+            .expect("elf chunk must fit under DATA_MAX_LENGTH"),
+        ..Account::default()
+    };
+    assert!(
+        target.account == Account::default() || target.account == already_this_header,
+        "header must be untouched, or already exactly this deployment's header"
+    );
+}
+
+/// Every segment target must be untouched — each segment is written exactly once, whether this
+/// is the transaction that first claims it or a later one revisiting the same range by mistake.
+fn check_segment_target(target: &AccountWithMetadata, planned: &PlannedAccount) {
     assert_eq!(
         target.account_id, planned.account_id,
         "wrong deployment target account"
@@ -313,7 +509,7 @@ fn check_deploy_target(target: &AccountWithMetadata, planned: &PlannedAccount) {
     assert_eq!(
         target.account,
         Account::default(),
-        "program already deployed"
+        "segment already deployed"
     );
 }
 
@@ -323,6 +519,7 @@ mod tests {
 
     const IMAGE_ID: ProgramId = [1, 2, 3, 4, 5, 6, 7, 8];
     const LOADER_ID: AccountId = AccountId::new([9; 32]);
+    const REAL_UPDATE_AUTH: AccountId = AccountId::new([42; 32]);
 
     fn plan_for(len: usize) -> DeployPlan {
         let user_elf = vec![0xAB_u8; len];
@@ -393,6 +590,382 @@ mod tests {
         let small = plan_for(1);
         let large = plan_for(5 * MAX_SEGMENT_DATA_LEN);
         assert_eq!(small.header.account_id, large.header.account_id);
+    }
+
+    #[test]
+    fn plan_deploy_range_batches_reassemble_to_the_same_plan() {
+        for total_len in [
+            1,
+            MAX_SEGMENT_DATA_LEN,
+            2 * MAX_SEGMENT_DATA_LEN,
+            2 * MAX_SEGMENT_DATA_LEN + 1,
+        ] {
+            let user_elf: Vec<u8> = (0..total_len)
+                .map(|i| {
+                    u8::try_from(i.checked_rem(251).expect("nonzero divisor"))
+                        .expect("value fits in u8")
+                })
+                .collect();
+            let whole = plan_deploy(LOADER_ID, IMAGE_ID, AccountId::default(), &user_elf);
+            let segment_count = u32::try_from(whole.segments.len()).unwrap();
+
+            // Split at every possible boundary into two batches.
+            for split in 0..whole.segments.len() {
+                let first_len = split
+                    .checked_add(1)
+                    .expect("split index fits")
+                    .min(whole.segments.len());
+                let byte_split = whole.segments[..first_len]
+                    .iter()
+                    .map(|s| s.data.len())
+                    .sum();
+                let (first_bytes, second_bytes) = user_elf.split_at(byte_split);
+
+                let batch1 = plan_deploy_range(
+                    LOADER_ID,
+                    IMAGE_ID,
+                    segment_count,
+                    AccountId::default(),
+                    0,
+                    first_bytes,
+                );
+                let batch2 = plan_deploy_range(
+                    LOADER_ID,
+                    IMAGE_ID,
+                    segment_count,
+                    AccountId::default(),
+                    u32::try_from(first_len).unwrap(),
+                    second_bytes,
+                );
+
+                let reassembled: Vec<_> = batch1
+                    .segments
+                    .iter()
+                    .chain(&batch2.segments)
+                    .map(|s| s.account_id)
+                    .collect();
+                let expected: Vec<_> = whole.segments.iter().map(|s| s.account_id).collect();
+                assert_eq!(
+                    reassembled, expected,
+                    "mismatch at total_len={total_len}, split={split}"
+                );
+                assert_eq!(batch1.header.account_id, whole.header.account_id);
+                assert_eq!(batch2.header.account_id, whole.header.account_id);
+            }
+        }
+    }
+
+    fn header_target(plan: &DeployPlan, existing: Account) -> AccountWithMetadata {
+        AccountWithMetadata {
+            account: existing,
+            is_authorized: false,
+            account_id: plan.header.account_id,
+        }
+    }
+
+    fn fresh_segment_targets(plan: &DeployPlan) -> Vec<AccountWithMetadata> {
+        plan.segments
+            .iter()
+            .map(|s| AccountWithMetadata {
+                account: Account::default(),
+                is_authorized: false,
+                account_id: s.account_id,
+            })
+            .collect()
+    }
+
+    fn signer(account_id: AccountId, is_authorized: bool) -> AccountWithMetadata {
+        AccountWithMetadata {
+            account: Account::default(),
+            is_authorized,
+            account_id,
+        }
+    }
+
+    #[test]
+    fn execute_deploy_single_batch_still_works() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+
+        let plan = plan_deploy(LOADER_ID, image_id, AccountId::default(), &user_elf);
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        pre_states.extend(fresh_segment_targets(&plan));
+
+        let post_states = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &user_elf,
+            image_id,
+            segment_count,
+            0,
+            AccountId::default(),
+        );
+        assert_eq!(post_states.len(), 1 + plan.segments.len());
+    }
+
+    #[test]
+    fn execute_deploy_two_batch_sequence_succeeds() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let plan = plan_deploy(LOADER_ID, image_id, REAL_UPDATE_AUTH, &user_elf);
+        assert!(plan.segments.len() > 1, "need a real multi-segment program");
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+        let split = plan.segments.len().checked_div(2).expect("nonzero divisor");
+        let byte_split: usize = plan.segments[..split].iter().map(|s| s.data.len()).sum();
+        let (first_bytes, second_bytes) = user_elf.split_at(byte_split);
+
+        // Batch 1: header (fresh) + signer + segments[..split]
+        let batch1_plan = plan_deploy_range(
+            LOADER_ID,
+            image_id,
+            segment_count,
+            REAL_UPDATE_AUTH,
+            0,
+            first_bytes,
+        );
+        let mut pre_states1 = vec![header_target(&batch1_plan, Account::default())];
+        pre_states1.push(signer(REAL_UPDATE_AUTH, true));
+        pre_states1.extend(fresh_segment_targets(&batch1_plan));
+        let post1 = execute_deploy(
+            LOADER_ID,
+            &pre_states1,
+            first_bytes,
+            image_id,
+            segment_count,
+            0,
+            REAL_UPDATE_AUTH,
+        );
+        assert_eq!(post1.len(), 2 + batch1_plan.segments.len());
+
+        // `execute_deploy`'s own return value leaves `program_owner` at the default placeholder
+        // — the caller (validated_state_diff's claim processing) is what sets the real owner
+        // once a Claim::Pda is approved. What batch 2 actually sees as the header's pre-state is
+        // the *post-claim-processing* account, so reconstruct that directly rather than reusing
+        // `post1[0].account()` verbatim.
+        let header_after_batch1 = Account {
+            program_owner: LOADER_ID,
+            data: Data::try_from(batch1_plan.header.data).unwrap(),
+            ..Account::default()
+        };
+
+        // Batch 2: header (already-deployed, matching) + signer + segments[split..]
+        let batch2_plan = plan_deploy_range(
+            LOADER_ID,
+            image_id,
+            segment_count,
+            REAL_UPDATE_AUTH,
+            u32::try_from(split).unwrap(),
+            second_bytes,
+        );
+        let mut pre_states2 = vec![header_target(&batch2_plan, header_after_batch1)];
+        pre_states2.push(signer(REAL_UPDATE_AUTH, true));
+        pre_states2.extend(fresh_segment_targets(&batch2_plan));
+        let post2 = execute_deploy(
+            LOADER_ID,
+            &pre_states2,
+            second_bytes,
+            image_id,
+            segment_count,
+            u32::try_from(split).unwrap(),
+            REAL_UPDATE_AUTH,
+        );
+        assert_eq!(post2.len(), 2 + batch2_plan.segments.len());
+    }
+
+    #[test]
+    #[should_panic(expected = "a partial Deploy requires a real update_auth")]
+    fn execute_deploy_rejects_a_partial_batch_with_default_update_auth() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let plan = plan_deploy(LOADER_ID, image_id, AccountId::default(), &user_elf);
+        assert!(plan.segments.len() > 1, "need a real multi-segment program");
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+        let split = plan.segments.len() - 1;
+        let byte_split: usize = plan.segments[..split].iter().map(|s| s.data.len()).sum();
+        let (first_bytes, _second_bytes) = user_elf.split_at(byte_split);
+
+        let batch_plan = plan_deploy_range(
+            LOADER_ID,
+            image_id,
+            segment_count,
+            AccountId::default(),
+            0,
+            first_bytes,
+        );
+        let mut pre_states = vec![header_target(&batch_plan, Account::default())];
+        pre_states.push(signer(AccountId::default(), true));
+        pre_states.extend(fresh_segment_targets(&batch_plan));
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            first_bytes,
+            image_id,
+            segment_count,
+            0,
+            AccountId::default(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "requires update_auth's signature")]
+    fn execute_deploy_rejects_a_partial_batch_without_update_auths_signature() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let plan = plan_deploy(LOADER_ID, image_id, REAL_UPDATE_AUTH, &user_elf);
+        assert!(plan.segments.len() > 1, "need a real multi-segment program");
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+        let split = plan.segments.len() - 1;
+        let byte_split: usize = plan.segments[..split].iter().map(|s| s.data.len()).sum();
+        let (first_bytes, _second_bytes) = user_elf.split_at(byte_split);
+
+        let batch_plan = plan_deploy_range(
+            LOADER_ID,
+            image_id,
+            segment_count,
+            REAL_UPDATE_AUTH,
+            0,
+            first_bytes,
+        );
+        let mut pre_states = vec![header_target(&batch_plan, Account::default())];
+        pre_states.push(signer(REAL_UPDATE_AUTH, false)); // present, but not signed
+        pre_states.extend(fresh_segment_targets(&batch_plan));
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            first_bytes,
+            image_id,
+            segment_count,
+            0,
+            REAL_UPDATE_AUTH,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "runs past the declared segment_count")]
+    fn execute_deploy_rejects_batch_past_declared_segment_count() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let real_segment_count = segment_count_for(&user_elf);
+        assert!(real_segment_count > 1, "need a real multi-segment program");
+
+        // Declare a segment_count of 1 (too small) while submitting the whole program.
+        let plan = plan_deploy_range(LOADER_ID, image_id, 1, AccountId::default(), 0, &user_elf);
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        pre_states.extend(fresh_segment_targets(&plan));
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &user_elf,
+            image_id,
+            1,
+            0,
+            AccountId::default(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "must include at least one segment")]
+    fn execute_deploy_rejects_header_only_batch() {
+        let plan = plan_deploy_range(LOADER_ID, IMAGE_ID, 2, REAL_UPDATE_AUTH, 2, &[]);
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        pre_states.push(signer(REAL_UPDATE_AUTH, true));
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &[],
+            IMAGE_ID,
+            2,
+            2,
+            REAL_UPDATE_AUTH,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "segment already deployed")]
+    fn execute_deploy_rejects_rewriting_a_written_segment() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let plan = plan_deploy(LOADER_ID, image_id, AccountId::default(), &user_elf);
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        // First segment already claimed (non-default), rest fresh.
+        let mut segments = fresh_segment_targets(&plan);
+        segments[0].account = Account {
+            data: Data::try_from(plan.segments[0].data.clone()).unwrap(),
+            ..Account::default()
+        };
+        pre_states.extend(segments);
+
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &user_elf,
+            image_id,
+            segment_count,
+            0,
+            AccountId::default(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "declared image_id does not match the submitted bytecode")]
+    fn execute_deploy_rejects_a_complete_batch_with_a_dishonest_image_id() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let dishonest_image_id = [99, 99, 99, 99, 99, 99, 99, 99];
+        let segment_count = segment_count_for(&user_elf);
+
+        let plan = plan_deploy(
+            LOADER_ID,
+            dishonest_image_id,
+            AccountId::default(),
+            &user_elf,
+        );
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        pre_states.extend(fresh_segment_targets(&plan));
+
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &user_elf,
+            dishonest_image_id,
+            segment_count,
+            0,
+            AccountId::default(),
+        );
     }
 
     #[test]

--- a/lez/programs/program_loader/core/src/lib.rs
+++ b/lez/programs/program_loader/core/src/lib.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 pub use lee_core::program::{PdaSeed, ProgramData};
 use lee_core::{
     account::{Account, AccountId, AccountWithMetadata, Data},
-    program::{AccountPostState, Claim, ProgramId},
+    program::{AccountPostState, Claim, DEFAULT_PROGRAM_OWNER, ProgramId},
 };
 
 const DEPLOY_HEADER_SEED_DOMAIN_SEPARATOR: AccountId =
@@ -28,23 +28,41 @@ pub const MAX_SEGMENT_DATA_LEN: usize = 96 * 1024;
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub enum Instruction {
-    /// Deploys a new program: writes its `ProgramData` header and as many bytecode segments as
-    /// its size requires (see [`MAX_SEGMENT_DATA_LEN`]), each claimed as a PDA of the loader.
+    /// Deploys a program, in whole or in part: writes its `ProgramData` header and the bytecode
+    /// segments this transaction's `raw_payload` covers, each claimed as a PDA of the loader.
+    /// One or more `Deploy`s (each covering a contiguous range of segments) complete a
+    /// deployment — see [`execute_deploy`] for exactly what each transaction requires.
     ///
     /// The bytecode itself travels via the dispatching message's `raw_payload`, not this
     /// instruction — see `Message::raw_payload`'s doc comment for why.
     ///
-    /// Required accounts (1 + `segment_count`, where `segment_count` is determined by the
-    /// submitted bytecode's length — see [`plan_deploy`]), in order:
-    /// - The target `ProgramData` header PDA account (must be `Account::default()`)
-    /// - The target segment PDA accounts holding the raw bytecode, in segment order (each must be
-    ///   `Account::default()`)
+    /// Required accounts, in order:
+    /// - The target `ProgramData` header PDA account (must be `Account::default()`, or already
+    ///   exactly this deployment's header — see [`execute_deploy`])
+    /// - If this transaction doesn't deliver the whole program in one shot: an account matching
+    ///   `update_auth`, signed (`is_authorized`) by its holder
+    /// - The target segment PDA accounts this transaction covers (`first_segment,
+    ///   first_segment+1, ...`), in order (each must be `Account::default()`)
     Deploy {
+        /// Caller-declared identity of the program being deployed. Verified immediately against
+        /// the real bytecode when a transaction delivers the whole program in one shot;
+        /// otherwise verified lazily by `V03State::get_program` once every segment exists — see
+        /// [`execute_deploy`].
+        image_id: ProgramId,
+        /// Total segment count for the whole deployment. Caller-declared for the same reason as
+        /// `image_id`: a transaction covering only part of the program can't derive it from its
+        /// own fragment. Must be identical across every transaction in one deployment.
+        segment_count: u32,
+        /// `segment_number` of this transaction's first segment (0-indexed); its remaining
+        /// segment accounts are `first_segment, first_segment+1, ...` in order.
+        first_segment: u32,
         /// Distinguishes independent deployments of identical bytecode (same `image_id`) from
         /// one another, so a second deployer never collides with an existing deployment's PDAs.
-        /// Also who may redeploy this same slot in the future once upgrade authority is
-        /// implemented (a future PR) — for now this is a placeholder with no enforcement.
-        /// `AccountId::default()` means no upgrade authority (immutable).
+        /// Also who may redeploy this same slot in the future once upgrade authority is fully
+        /// implemented (a future PR), and — already enforced now — who must sign any transaction
+        /// that can't verify itself immediately (see [`execute_deploy`]). `AccountId::default()`
+        /// means no upgrade authority (immutable); such a program can only be deployed in a
+        /// single, self-contained transaction, since there's no key to sign a partial one with.
         update_auth: AccountId,
     },
 }
@@ -187,26 +205,29 @@ pub fn segment_account_id(
     )
 }
 
-/// Computes the account shape (header + N bytecode segments, chunked at
-/// [`MAX_SEGMENT_DATA_LEN`]) for deploying `user_elf` at `image_id` under `update_auth`.
+/// Plans the account shape for one batch of a (possibly multi-transaction) deploy.
 ///
-/// The single source of truth both [`execute_deploy`] and `V03State::insert_program` build from —
-/// so live deploys and genesis-seeded programs can never diverge on chunk boundaries, ordering,
-/// or PDA derivation.
+/// Builds the header (unchanged formula — always `segment_number` 0, independent of
+/// `segment_count`, so [`immutable_deploy_account_id`] stays stable regardless of how a deploy is
+/// batched) plus `batch_user_elf` chunked at [`MAX_SEGMENT_DATA_LEN`], numbered `first_segment,
+/// first_segment+1, ...`.
+///
+/// `segment_count` is the *total* across the whole deployment, not just this batch — written
+/// into the header's `ProgramData` identically by every batch, so [`execute_deploy`]'s header
+/// check can catch a caller who declares a different total between transactions. [`plan_deploy`]
+/// is the single-batch (whole program, `first_segment` 0) special case of this — the single
+/// source of truth both [`execute_deploy`] and `V03State::insert_program` build from, so live
+/// deploys and genesis-seeded programs can never diverge on chunk boundaries, ordering, or PDA
+/// derivation.
 #[must_use]
-pub fn plan_deploy(
+pub fn plan_deploy_range(
     loader_account_id: AccountId,
     image_id: ProgramId,
+    segment_count: u32,
     update_auth: AccountId,
-    user_elf: &[u8],
+    first_segment: u32,
+    batch_user_elf: &[u8],
 ) -> DeployPlan {
-    let chunks: Vec<&[u8]> = if user_elf.is_empty() {
-        vec![&[]]
-    } else {
-        user_elf.chunks(MAX_SEGMENT_DATA_LEN).collect()
-    };
-    let segment_count = u32::try_from(chunks.len()).expect("segment count fits in u32");
-
     let header_seed = header_pda_seed(image_id, 0, update_auth);
     let header = PlannedAccount {
         account_id: AccountId::for_public_pda(&loader_account_id, &header_seed),
@@ -219,11 +240,23 @@ pub fn plan_deploy(
         .expect("ProgramData borsh serialization should not fail"),
     };
 
+    // An empty program still needs exactly one (empty) segment to exist — but only when this
+    // batch is the whole thing; an empty *partial* batch is a caller error execute_deploy's own
+    // non-empty-batch assertion rejects, not something to paper over here.
+    let chunks: Vec<&[u8]> =
+        if batch_user_elf.is_empty() && first_segment == 0 && segment_count <= 1 {
+            vec![&[]]
+        } else {
+            batch_user_elf.chunks(MAX_SEGMENT_DATA_LEN).collect()
+        };
+
     let segments = chunks
         .into_iter()
         .enumerate()
         .map(|(i, chunk)| {
-            let segment_number = u32::try_from(i).expect("segment index fits in u32");
+            let segment_number = first_segment
+                .checked_add(u32::try_from(i).expect("segment index fits in u32"))
+                .expect("segment number fits in u32");
             let seed = segment_pda_seed(image_id, segment_number, update_auth);
             PlannedAccount {
                 account_id: AccountId::for_public_pda(&loader_account_id, &seed),
@@ -234,6 +267,40 @@ pub fn plan_deploy(
         .collect();
 
     DeployPlan { header, segments }
+}
+
+/// Computes the account shape (header + N bytecode segments) for deploying the whole of
+/// `user_elf` at `image_id` under `update_auth` in a single batch. See [`plan_deploy_range`].
+#[must_use]
+pub fn plan_deploy(
+    loader_account_id: AccountId,
+    image_id: ProgramId,
+    update_auth: AccountId,
+    user_elf: &[u8],
+) -> DeployPlan {
+    let segment_count = segment_count_for(user_elf);
+    plan_deploy_range(
+        loader_account_id,
+        image_id,
+        segment_count,
+        update_auth,
+        0,
+        user_elf,
+    )
+}
+
+/// Computes the total segment count deploying `user_elf` would require.
+///
+/// At [`MAX_SEGMENT_DATA_LEN`], without building the full plan — what the first transaction of a
+/// multi-transaction deploy needs to declare before the whole program exists on chain.
+#[must_use]
+pub fn segment_count_for(user_elf: &[u8]) -> u32 {
+    let n = if user_elf.is_empty() {
+        1
+    } else {
+        user_elf.len().div_ceil(MAX_SEGMENT_DATA_LEN)
+    };
+    u32::try_from(n).expect("segment count fits in u32")
 }
 
 /// The dispatch address a program with `image_id` lives at once deployed via `Deploy` with no
@@ -251,46 +318,148 @@ pub fn immutable_deploy_account_id(image_id: ProgramId) -> AccountId {
     )
 }
 
-/// Executes the `Deploy` instruction.
+/// Executes one `Deploy` transaction — either a whole deployment in one shot, or one batch of a
+/// multi-transaction deployment.
 ///
-/// Verifies `user_elf` decodes as a valid RISC0 program (combined with the assumed
-/// [`KERNEL_ELF`]), derives its header and segment PDAs (chunking `user_elf` across as many
-/// segments as [`plan_deploy`] reports), and claims all of them.
+/// `image_id`/`segment_count` are caller-declared, not derived from `user_elf_batch` (a batch
+/// covering only part of the program can't derive either from its own fragment). Whether that
+/// declaration is trustworthy going into this call, and consequently what this transaction must
+/// additionally prove, depends on whether `first_segment == 0` and `user_elf_batch` covers all
+/// `segment_count` segments — i.e. whether this transaction is the whole deployment:
 ///
-/// Called natively from dispatch's `PROGRAM_LOADER_ACCOUNT_ID` shortcut (see that constant's
-/// doc comment in `lee_core::program`) — `Deploy` has no guest binary of its own.
+/// - **Whole deployment in one shot**: `user_elf_batch` is independently decoded and its real
+///   `image_id` recomputed (combined with the assumed [`KERNEL_ELF`]) and checked against the
+///   declared one right here — exactly as trustworthy as a single-transaction deploy, no
+///   signature required.
+/// - **A genuine partial batch**: `image_id`/`segment_count` can't be verified from what this
+///   transaction alone carries — [`V03State::get_program`] only catches a mismatch once every
+///   segment eventually exists. In the meantime, this transaction must instead prove control of
+///   `update_auth`: `update_auth` must be non-default (there is no key to sign a partial deploy
+///   of an immutable program with), included as this call's second `pre_states` entry, and
+///   `is_authorized`. Every transaction in a partial sequence re-proves this independently, so no
+///   one else can inject a rogue continuation into someone else's in-progress deployment either.
+///
+/// Derives the header and this batch's segment PDAs (chunking `user_elf_batch` across as many
+/// segments as it covers, starting at `first_segment` — see [`plan_deploy_range`]) and claims
+/// all of them. The header target may be `Account::default()` (starting a new deployment) or
+/// already exactly this deployment's header (continuing one) — every other target must be
+/// `Account::default()`, since each segment is written exactly once.
+///
+/// Called natively from dispatch's `PROGRAM_LOADER_ACCOUNT_ID` shortcut (see that
+/// constant's doc comment in `lee_core::program`) — `Deploy` has no guest binary of its own.
 #[must_use]
 pub fn execute_deploy(
     self_account_id: AccountId,
     pre_states: &[AccountWithMetadata],
-    user_elf: &[u8],
+    user_elf_batch: &[u8],
+    image_id: ProgramId,
+    segment_count: u32,
+    first_segment: u32,
     update_auth: AccountId,
 ) -> Vec<AccountPostState> {
-    let image_id =
-        compute_image_id(user_elf).expect("user_elf must decode as a valid RISC0 program binary");
-    let plan = plan_deploy(self_account_id, image_id, update_auth, user_elf);
-
-    let expected_len = plan
-        .segments
-        .len()
-        .checked_add(1)
-        .expect("segment count fits in usize");
-    assert_eq!(
-        pre_states.len(),
-        expected_len,
-        "Deploy requires exactly 1 header + segment_count segment accounts"
+    let plan = plan_deploy_range(
+        self_account_id,
+        image_id,
+        segment_count,
+        update_auth,
+        first_segment,
+        user_elf_batch,
     );
-    let (header_target, segment_targets) =
-        pre_states.split_first().expect("checked non-empty above");
+    let batch_end = first_segment
+        .checked_add(u32::try_from(plan.segments.len()).expect("segment count fits in u32"))
+        .expect("no overflow");
+    assert!(
+        batch_end <= segment_count,
+        "Deploy batch runs past the declared segment_count"
+    );
+    let is_complete = first_segment == 0 && batch_end == segment_count;
 
-    check_deploy_target(header_target, &plan.header);
+    let (header_target, update_auth_target, segment_targets) = if is_complete {
+        let real_image_id = compute_image_id(user_elf_batch)
+            .expect("user_elf must decode as a valid RISC0 program binary");
+        assert_eq!(
+            image_id, real_image_id,
+            "declared image_id does not match the submitted bytecode"
+        );
+        let (header_target, segment_targets) = pre_states
+            .split_first()
+            .expect("Deploy requires at least a header account");
+        (header_target, None, segment_targets)
+    } else {
+        assert_ne!(
+            update_auth,
+            AccountId::default(),
+            "a partial Deploy requires a real update_auth - an immutable program can only be \
+             deployed in a single, self-contained transaction"
+        );
+        let (header_target, rest) = pre_states
+            .split_first()
+            .expect("Deploy requires at least a header account");
+        let (update_auth_target, segment_targets) = rest
+            .split_first()
+            .expect("a partial Deploy requires an update_auth signer account after the header");
+        assert_eq!(
+            update_auth_target.account_id, update_auth,
+            "second account of a partial Deploy must be the update_auth account"
+        );
+        assert!(
+            update_auth_target.is_authorized,
+            "a partial Deploy requires update_auth's signature"
+        );
+        (header_target, Some(update_auth_target), segment_targets)
+    };
+
+    assert!(
+        !plan.segments.is_empty(),
+        "Deploy batch must include at least one segment"
+    );
+    assert_eq!(
+        segment_targets.len(),
+        plan.segments.len(),
+        "Deploy requires exactly one target account per segment in this batch"
+    );
+
+    check_header_target(self_account_id, header_target, &plan.header);
     for (target, planned) in segment_targets.iter().zip(&plan.segments) {
-        check_deploy_target(target, planned);
+        check_segment_target(target, planned);
     }
 
-    std::iter::once(&plan.header)
-        .chain(&plan.segments)
-        .map(|planned| {
+    // pre_states/post_states are matched positionally (see validate_execution), so an
+    // update_auth signer slot present in pre_states must get a matching entry here too. Its
+    // nonce gets bumped just by signing (independent of this program), so once it's ever
+    // acted as a signer it's no longer `Account::default()` — left unclaimed, that combination
+    // (non-default account, default owner) is permanently rejected by validate_execution on any
+    // later batch that reuses it. Claiming it under the loader on its first use avoids that;
+    // later batches then see it already loader-owned and just pass it through unchanged.
+    let update_auth_post_state = update_auth_target.map(|target| {
+        if target.account.program_owner == DEFAULT_PROGRAM_OWNER {
+            AccountPostState::new_claimed(target.account.clone(), Claim::Authorized)
+        } else {
+            AccountPostState::new(target.account.clone())
+        }
+    });
+
+    // A fresh header claims default->owned via Claim::Pda, same as -7. An idempotent re-claim
+    // (a later batch in the same sequence revisiting the header) must mirror the pre-state
+    // exactly instead — validate_execution rejects any post-state whose program_owner differs
+    // from pre, and the header's real program_owner is already set from the earlier batch's
+    // claim by this point, not the default placeholder a fresh claim's post-state carries.
+    let header_post_state = if header_target.account == Account::default() {
+        AccountPostState::new_claimed(
+            Account {
+                data: Data::try_from(plan.header.data.clone())
+                    .expect("elf chunk must fit under DATA_MAX_LENGTH"),
+                ..Account::default()
+            },
+            Claim::Pda(plan.header.seed),
+        )
+    } else {
+        AccountPostState::new(header_target.account.clone())
+    };
+
+    std::iter::once(header_post_state)
+        .chain(update_auth_post_state)
+        .chain(plan.segments.iter().map(|planned| {
             AccountPostState::new_claimed(
                 Account {
                     data: Data::try_from(planned.data.clone())
@@ -299,11 +468,36 @@ pub fn execute_deploy(
                 },
                 Claim::Pda(planned.seed),
             )
-        })
+        }))
         .collect()
 }
 
-fn check_deploy_target(target: &AccountWithMetadata, planned: &PlannedAccount) {
+/// The header may either be a fresh claim (`Account::default()`) or an idempotent re-claim of
+/// exactly this deployment's already-written header — never anything else.
+fn check_header_target(
+    self_account_id: AccountId,
+    target: &AccountWithMetadata,
+    planned: &PlannedAccount,
+) {
+    assert_eq!(
+        target.account_id, planned.account_id,
+        "wrong deployment target account"
+    );
+    let already_this_header = Account {
+        program_owner: self_account_id,
+        data: Data::try_from(planned.data.clone())
+            .expect("elf chunk must fit under DATA_MAX_LENGTH"),
+        ..Account::default()
+    };
+    assert!(
+        target.account == Account::default() || target.account == already_this_header,
+        "header must be untouched, or already exactly this deployment's header"
+    );
+}
+
+/// Every segment target must be untouched — each segment is written exactly once, whether this
+/// is the transaction that first claims it or a later one revisiting the same range by mistake.
+fn check_segment_target(target: &AccountWithMetadata, planned: &PlannedAccount) {
     assert_eq!(
         target.account_id, planned.account_id,
         "wrong deployment target account"
@@ -311,7 +505,7 @@ fn check_deploy_target(target: &AccountWithMetadata, planned: &PlannedAccount) {
     assert_eq!(
         target.account,
         Account::default(),
-        "program already deployed"
+        "segment already deployed"
     );
 }
 
@@ -321,6 +515,7 @@ mod tests {
 
     const IMAGE_ID: ProgramId = [1, 2, 3, 4, 5, 6, 7, 8];
     const LOADER_ID: AccountId = AccountId::new([9; 32]);
+    const REAL_UPDATE_AUTH: AccountId = AccountId::new([42; 32]);
 
     fn plan_for(len: usize) -> DeployPlan {
         let user_elf = vec![0xAB_u8; len];
@@ -391,6 +586,382 @@ mod tests {
         let small = plan_for(1);
         let large = plan_for(5 * MAX_SEGMENT_DATA_LEN);
         assert_eq!(small.header.account_id, large.header.account_id);
+    }
+
+    #[test]
+    fn plan_deploy_range_batches_reassemble_to_the_same_plan() {
+        for total_len in [
+            1,
+            MAX_SEGMENT_DATA_LEN,
+            2 * MAX_SEGMENT_DATA_LEN,
+            2 * MAX_SEGMENT_DATA_LEN + 1,
+        ] {
+            let user_elf: Vec<u8> = (0..total_len)
+                .map(|i| {
+                    u8::try_from(i.checked_rem(251).expect("nonzero divisor"))
+                        .expect("value fits in u8")
+                })
+                .collect();
+            let whole = plan_deploy(LOADER_ID, IMAGE_ID, AccountId::default(), &user_elf);
+            let segment_count = u32::try_from(whole.segments.len()).unwrap();
+
+            // Split at every possible boundary into two batches.
+            for split in 0..whole.segments.len() {
+                let first_len = split
+                    .checked_add(1)
+                    .expect("split index fits")
+                    .min(whole.segments.len());
+                let byte_split = whole.segments[..first_len]
+                    .iter()
+                    .map(|s| s.data.len())
+                    .sum();
+                let (first_bytes, second_bytes) = user_elf.split_at(byte_split);
+
+                let batch1 = plan_deploy_range(
+                    LOADER_ID,
+                    IMAGE_ID,
+                    segment_count,
+                    AccountId::default(),
+                    0,
+                    first_bytes,
+                );
+                let batch2 = plan_deploy_range(
+                    LOADER_ID,
+                    IMAGE_ID,
+                    segment_count,
+                    AccountId::default(),
+                    u32::try_from(first_len).unwrap(),
+                    second_bytes,
+                );
+
+                let reassembled: Vec<_> = batch1
+                    .segments
+                    .iter()
+                    .chain(&batch2.segments)
+                    .map(|s| s.account_id)
+                    .collect();
+                let expected: Vec<_> = whole.segments.iter().map(|s| s.account_id).collect();
+                assert_eq!(
+                    reassembled, expected,
+                    "mismatch at total_len={total_len}, split={split}"
+                );
+                assert_eq!(batch1.header.account_id, whole.header.account_id);
+                assert_eq!(batch2.header.account_id, whole.header.account_id);
+            }
+        }
+    }
+
+    fn header_target(plan: &DeployPlan, existing: Account) -> AccountWithMetadata {
+        AccountWithMetadata {
+            account: existing,
+            is_authorized: false,
+            account_id: plan.header.account_id,
+        }
+    }
+
+    fn fresh_segment_targets(plan: &DeployPlan) -> Vec<AccountWithMetadata> {
+        plan.segments
+            .iter()
+            .map(|s| AccountWithMetadata {
+                account: Account::default(),
+                is_authorized: false,
+                account_id: s.account_id,
+            })
+            .collect()
+    }
+
+    fn signer(account_id: AccountId, is_authorized: bool) -> AccountWithMetadata {
+        AccountWithMetadata {
+            account: Account::default(),
+            is_authorized,
+            account_id,
+        }
+    }
+
+    #[test]
+    fn execute_deploy_single_batch_still_works() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+
+        let plan = plan_deploy(LOADER_ID, image_id, AccountId::default(), &user_elf);
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        pre_states.extend(fresh_segment_targets(&plan));
+
+        let post_states = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &user_elf,
+            image_id,
+            segment_count,
+            0,
+            AccountId::default(),
+        );
+        assert_eq!(post_states.len(), 1 + plan.segments.len());
+    }
+
+    #[test]
+    fn execute_deploy_two_batch_sequence_succeeds() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let plan = plan_deploy(LOADER_ID, image_id, REAL_UPDATE_AUTH, &user_elf);
+        assert!(plan.segments.len() > 1, "need a real multi-segment program");
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+        let split = plan.segments.len().checked_div(2).expect("nonzero divisor");
+        let byte_split: usize = plan.segments[..split].iter().map(|s| s.data.len()).sum();
+        let (first_bytes, second_bytes) = user_elf.split_at(byte_split);
+
+        // Batch 1: header (fresh) + signer + segments[..split]
+        let batch1_plan = plan_deploy_range(
+            LOADER_ID,
+            image_id,
+            segment_count,
+            REAL_UPDATE_AUTH,
+            0,
+            first_bytes,
+        );
+        let mut pre_states1 = vec![header_target(&batch1_plan, Account::default())];
+        pre_states1.push(signer(REAL_UPDATE_AUTH, true));
+        pre_states1.extend(fresh_segment_targets(&batch1_plan));
+        let post1 = execute_deploy(
+            LOADER_ID,
+            &pre_states1,
+            first_bytes,
+            image_id,
+            segment_count,
+            0,
+            REAL_UPDATE_AUTH,
+        );
+        assert_eq!(post1.len(), 2 + batch1_plan.segments.len());
+
+        // `execute_deploy`'s own return value leaves `program_owner` at the default placeholder
+        // — the caller (validated_state_diff's claim processing) is what sets the real owner
+        // once a Claim::Pda is approved. What batch 2 actually sees as the header's pre-state is
+        // the *post-claim-processing* account, so reconstruct that directly rather than reusing
+        // `post1[0].account()` verbatim.
+        let header_after_batch1 = Account {
+            program_owner: LOADER_ID,
+            data: Data::try_from(batch1_plan.header.data).unwrap(),
+            ..Account::default()
+        };
+
+        // Batch 2: header (already-deployed, matching) + signer + segments[split..]
+        let batch2_plan = plan_deploy_range(
+            LOADER_ID,
+            image_id,
+            segment_count,
+            REAL_UPDATE_AUTH,
+            u32::try_from(split).unwrap(),
+            second_bytes,
+        );
+        let mut pre_states2 = vec![header_target(&batch2_plan, header_after_batch1)];
+        pre_states2.push(signer(REAL_UPDATE_AUTH, true));
+        pre_states2.extend(fresh_segment_targets(&batch2_plan));
+        let post2 = execute_deploy(
+            LOADER_ID,
+            &pre_states2,
+            second_bytes,
+            image_id,
+            segment_count,
+            u32::try_from(split).unwrap(),
+            REAL_UPDATE_AUTH,
+        );
+        assert_eq!(post2.len(), 2 + batch2_plan.segments.len());
+    }
+
+    #[test]
+    #[should_panic(expected = "a partial Deploy requires a real update_auth")]
+    fn execute_deploy_rejects_a_partial_batch_with_default_update_auth() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let plan = plan_deploy(LOADER_ID, image_id, AccountId::default(), &user_elf);
+        assert!(plan.segments.len() > 1, "need a real multi-segment program");
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+        let split = plan.segments.len() - 1;
+        let byte_split: usize = plan.segments[..split].iter().map(|s| s.data.len()).sum();
+        let (first_bytes, _second_bytes) = user_elf.split_at(byte_split);
+
+        let batch_plan = plan_deploy_range(
+            LOADER_ID,
+            image_id,
+            segment_count,
+            AccountId::default(),
+            0,
+            first_bytes,
+        );
+        let mut pre_states = vec![header_target(&batch_plan, Account::default())];
+        pre_states.push(signer(AccountId::default(), true));
+        pre_states.extend(fresh_segment_targets(&batch_plan));
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            first_bytes,
+            image_id,
+            segment_count,
+            0,
+            AccountId::default(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "requires update_auth's signature")]
+    fn execute_deploy_rejects_a_partial_batch_without_update_auths_signature() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let plan = plan_deploy(LOADER_ID, image_id, REAL_UPDATE_AUTH, &user_elf);
+        assert!(plan.segments.len() > 1, "need a real multi-segment program");
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+        let split = plan.segments.len() - 1;
+        let byte_split: usize = plan.segments[..split].iter().map(|s| s.data.len()).sum();
+        let (first_bytes, _second_bytes) = user_elf.split_at(byte_split);
+
+        let batch_plan = plan_deploy_range(
+            LOADER_ID,
+            image_id,
+            segment_count,
+            REAL_UPDATE_AUTH,
+            0,
+            first_bytes,
+        );
+        let mut pre_states = vec![header_target(&batch_plan, Account::default())];
+        pre_states.push(signer(REAL_UPDATE_AUTH, false)); // present, but not signed
+        pre_states.extend(fresh_segment_targets(&batch_plan));
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            first_bytes,
+            image_id,
+            segment_count,
+            0,
+            REAL_UPDATE_AUTH,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "runs past the declared segment_count")]
+    fn execute_deploy_rejects_batch_past_declared_segment_count() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let real_segment_count = segment_count_for(&user_elf);
+        assert!(real_segment_count > 1, "need a real multi-segment program");
+
+        // Declare a segment_count of 1 (too small) while submitting the whole program.
+        let plan = plan_deploy_range(LOADER_ID, image_id, 1, AccountId::default(), 0, &user_elf);
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        pre_states.extend(fresh_segment_targets(&plan));
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &user_elf,
+            image_id,
+            1,
+            0,
+            AccountId::default(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "must include at least one segment")]
+    fn execute_deploy_rejects_header_only_batch() {
+        let plan = plan_deploy_range(LOADER_ID, IMAGE_ID, 2, REAL_UPDATE_AUTH, 2, &[]);
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        pre_states.push(signer(REAL_UPDATE_AUTH, true));
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &[],
+            IMAGE_ID,
+            2,
+            2,
+            REAL_UPDATE_AUTH,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "segment already deployed")]
+    fn execute_deploy_rejects_rewriting_a_written_segment() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let image_id = program.id();
+        let plan = plan_deploy(LOADER_ID, image_id, AccountId::default(), &user_elf);
+        let segment_count = u32::try_from(plan.segments.len()).unwrap();
+
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        // First segment already claimed (non-default), rest fresh.
+        let mut segments = fresh_segment_targets(&plan);
+        segments[0].account = Account {
+            data: Data::try_from(plan.segments[0].data.clone()).unwrap(),
+            ..Account::default()
+        };
+        pre_states.extend(segments);
+
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &user_elf,
+            image_id,
+            segment_count,
+            0,
+            AccountId::default(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "declared image_id does not match the submitted bytecode")]
+    fn execute_deploy_rejects_a_complete_batch_with_a_dishonest_image_id() {
+        let program = test_programs::claimer();
+        let user_elf = extract_user_elf(program.elf()).unwrap();
+        let dishonest_image_id = [99, 99, 99, 99, 99, 99, 99, 99];
+        let segment_count = segment_count_for(&user_elf);
+
+        let plan = plan_deploy(
+            LOADER_ID,
+            dishonest_image_id,
+            AccountId::default(),
+            &user_elf,
+        );
+        let mut pre_states = vec![header_target(&plan, Account::default())];
+        pre_states.extend(fresh_segment_targets(&plan));
+
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "should_panic test - the panic is the assertion, return value unused"
+        )]
+        let _ = execute_deploy(
+            LOADER_ID,
+            &pre_states,
+            &user_elf,
+            dishonest_image_id,
+            segment_count,
+            0,
+            AccountId::default(),
+        );
     }
 
     #[test]

--- a/lez/programs/program_loader/core/src/lib.rs
+++ b/lez/programs/program_loader/core/src/lib.rs
@@ -41,8 +41,8 @@ pub enum Instruction {
     ///   exactly this deployment's header — see [`execute_deploy`])
     /// - If this transaction doesn't deliver the whole program in one shot: an account matching
     ///   `update_auth`, signed (`is_authorized`) by its holder
-    /// - The target segment PDA accounts this transaction covers (`first_segment,
-    ///   first_segment+1, ...`), in order (each must be `Account::default()`)
+    /// - The target segment PDA accounts this transaction covers (`first_segment, first_segment+1,
+    ///   ...`), in order (each must be `Account::default()`)
     Deploy {
         /// Caller-declared identity of the program being deployed. Verified immediately against
         /// the real bytecode when a transaction delivers the whole program in one shot;
@@ -329,13 +329,13 @@ pub fn immutable_deploy_account_id(image_id: ProgramId) -> AccountId {
 ///
 /// - **Whole deployment in one shot**: `user_elf_batch` is independently decoded and its real
 ///   `image_id` recomputed (combined with the assumed [`KERNEL_ELF`]) and checked against the
-///   declared one right here — exactly as trustworthy as a single-transaction deploy, no
-///   signature required.
+///   declared one right here — exactly as trustworthy as a single-transaction deploy, no signature
+///   required.
 /// - **A genuine partial batch**: `image_id`/`segment_count` can't be verified from what this
 ///   transaction alone carries — [`V03State::get_program`] only catches a mismatch once every
 ///   segment eventually exists. In the meantime, this transaction must instead prove control of
-///   `update_auth`: `update_auth` must be non-default (there is no key to sign a partial deploy
-///   of an immutable program with), included as this call's second `pre_states` entry, and
+///   `update_auth`: `update_auth` must be non-default (there is no key to sign a partial deploy of
+///   an immutable program with), included as this call's second `pre_states` entry, and
 ///   `is_authorized`. Every transaction in a partial sequence re-proves this independently, so no
 ///   one else can inject a rogue continuation into someone else's in-progress deployment either.
 ///

--- a/lez/programs/program_loader/core/src/lib.rs
+++ b/lez/programs/program_loader/core/src/lib.rs
@@ -41,8 +41,8 @@ pub enum Instruction {
     ///   exactly this deployment's header — see [`execute_deploy`])
     /// - If this transaction doesn't deliver the whole program in one shot: an account matching
     ///   `update_auth`, signed (`is_authorized`) by its holder
-    /// - The target segment PDA accounts this transaction covers (`first_segment,
-    ///   first_segment+1, ...`), in order (each must be `Account::default()`)
+    /// - The target segment PDA accounts this transaction covers (`first_segment, first_segment+1,
+    ///   ...`), in order (each must be `Account::default()`)
     Deploy {
         /// Caller-declared identity of the program being deployed. Verified immediately against
         /// the real bytecode when a transaction delivers the whole program in one shot;
@@ -333,13 +333,13 @@ pub fn immutable_deploy_account_id(image_id: ProgramId) -> AccountId {
 ///
 /// - **Whole deployment in one shot**: `user_elf_batch` is independently decoded and its real
 ///   `image_id` recomputed (combined with the assumed [`KERNEL_ELF`]) and checked against the
-///   declared one right here — exactly as trustworthy as a single-transaction deploy, no
-///   signature required.
+///   declared one right here — exactly as trustworthy as a single-transaction deploy, no signature
+///   required.
 /// - **A genuine partial batch**: `image_id`/`segment_count` can't be verified from what this
 ///   transaction alone carries — [`V03State::get_program`] only catches a mismatch once every
 ///   segment eventually exists. In the meantime, this transaction must instead prove control of
-///   `update_auth`: `update_auth` must be non-default (there is no key to sign a partial deploy
-///   of an immutable program with), included as this call's second `pre_states` entry, and
+///   `update_auth`: `update_auth` must be non-default (there is no key to sign a partial deploy of
+///   an immutable program with), included as this call's second `pre_states` entry, and
 ///   `is_authorized`. Every transaction in a partial sequence re-proves this independently, so no
 ///   one else can inject a rogue continuation into someone else's in-progress deployment either.
 ///

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -3806,16 +3806,16 @@ fn deploy_transactions(
                 let segment_number = first_segment
                     .checked_add(u32::try_from(i).unwrap())
                     .unwrap();
-                program_loader_core::deploy_segment_account_id(
-                    DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+                program_loader_core::segment_account_id(
+                    PROGRAM_LOADER_ACCOUNT_ID,
                     image_id,
                     segment_number,
                     update_auth,
                 )
             })
             .collect();
-        let header = program_loader_core::deploy_header_account_id(
-            DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        let header = program_loader_core::header_account_id(
+            PROGRAM_LOADER_ACCOUNT_ID,
             image_id,
             0,
             update_auth,
@@ -4039,16 +4039,12 @@ fn loader_deploys_program_across_multiple_transactions() {
     let key = PrivateKey::try_new([11; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
-        image_id,
-        0,
-        update_auth,
-    );
+    let header =
+        program_loader_core::header_account_id(PROGRAM_LOADER_ACCOUNT_ID, image_id, 0, update_auth);
     let segment_ids: Vec<AccountId> = (0..segment_count)
         .map(|i| {
-            program_loader_core::deploy_segment_account_id(
-                DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+            program_loader_core::segment_account_id(
+                PROGRAM_LOADER_ACCOUNT_ID,
                 image_id,
                 i,
                 update_auth,
@@ -4100,16 +4096,12 @@ fn loader_deploy_batches_can_land_out_of_order() {
     let key = PrivateKey::try_new([12; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
-        image_id,
-        0,
-        update_auth,
-    );
+    let header =
+        program_loader_core::header_account_id(PROGRAM_LOADER_ACCOUNT_ID, image_id, 0, update_auth);
     let segment_ids: Vec<AccountId> = (0..segment_count)
         .map(|i| {
-            program_loader_core::deploy_segment_account_id(
-                DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+            program_loader_core::segment_account_id(
+                PROGRAM_LOADER_ACCOUNT_ID,
                 image_id,
                 i,
                 update_auth,
@@ -4178,12 +4170,7 @@ fn loader_get_program_returns_none_for_abandoned_multi_tx_deploy() {
     let txs = deploy_transactions(&bytecode, &[1, remaining_segments], update_auth, &key);
     let header = {
         let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-        program_loader_core::deploy_header_account_id(
-            DEPLOYMENT_PROGRAM_ACCOUNT_ID,
-            image_id,
-            0,
-            update_auth,
-        )
+        program_loader_core::header_account_id(PROGRAM_LOADER_ACCOUNT_ID, image_id, 0, update_auth)
     };
 
     // Only the first batch ever lands — the deployer abandons the rest of the sequence.
@@ -4212,14 +4199,10 @@ fn loader_rejects_a_partial_deploy_batch_with_default_update_auth() {
 
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     let update_auth = AccountId::default();
-    let header = program_loader_core::deploy_header_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
-        image_id,
-        0,
-        update_auth,
-    );
-    let segment0 = program_loader_core::deploy_segment_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+    let header =
+        program_loader_core::header_account_id(PROGRAM_LOADER_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::segment_account_id(
+        PROGRAM_LOADER_ACCOUNT_ID,
         image_id,
         0,
         update_auth,
@@ -4262,14 +4245,10 @@ fn loader_rejects_a_partial_deploy_batch_without_a_valid_signature() {
     let key = PrivateKey::try_new([14; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
-        image_id,
-        0,
-        update_auth,
-    );
-    let segment0 = program_loader_core::deploy_segment_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+    let header =
+        program_loader_core::header_account_id(PROGRAM_LOADER_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::segment_account_id(
+        PROGRAM_LOADER_ACCOUNT_ID,
         image_id,
         0,
         update_auth,
@@ -4312,20 +4291,16 @@ fn loader_rejects_header_racing_with_a_different_segment_count() {
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     // The header PDA depends on (image_id, update_auth) only, not on segment_count — verified
     // separately by header_pda_is_independent_of_segment_count in loader_core.
-    let header = program_loader_core::deploy_header_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+    let header =
+        program_loader_core::header_account_id(PROGRAM_LOADER_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::segment_account_id(
+        PROGRAM_LOADER_ACCOUNT_ID,
         image_id,
         0,
         update_auth,
     );
-    let segment0 = program_loader_core::deploy_segment_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
-        image_id,
-        0,
-        update_auth,
-    );
-    let segment1 = program_loader_core::deploy_segment_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+    let segment1 = program_loader_core::segment_account_id(
+        PROGRAM_LOADER_ACCOUNT_ID,
         image_id,
         1,
         update_auth,
@@ -4382,14 +4357,10 @@ fn loader_rejects_overlapping_segment_rewrite() {
     let key = PrivateKey::try_new([16; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
-        image_id,
-        0,
-        update_auth,
-    );
-    let segment0 = program_loader_core::deploy_segment_account_id(
-        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+    let header =
+        program_loader_core::header_account_id(PROGRAM_LOADER_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::segment_account_id(
+        PROGRAM_LOADER_ACCOUNT_ID,
         image_id,
         0,
         update_auth,

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -152,19 +152,19 @@ fn setup_sequencer_config() -> SequencerConfig {
 #[test]
 fn only_the_cross_zone_inbox_is_sequencer_only() {
     assert!(is_sequencer_only_program(
-        program_program_loader_core::immutable_deploy_account_id(programs::cross_zone_inbox().id())
+        program_loader_core::immutable_deploy_account_id(programs::cross_zone_inbox().id())
     ));
     assert!(!is_sequencer_only_program(
-        program_program_loader_core::immutable_deploy_account_id(programs::cross_zone_outbox().id())
+        program_loader_core::immutable_deploy_account_id(programs::cross_zone_outbox().id())
     ));
     assert!(!is_sequencer_only_program(
-        program_program_loader_core::immutable_deploy_account_id(programs::wrapped_token().id())
+        program_loader_core::immutable_deploy_account_id(programs::wrapped_token().id())
     ));
     assert!(!is_sequencer_only_program(
-        program_program_loader_core::immutable_deploy_account_id(programs::ping_sender().id())
+        program_loader_core::immutable_deploy_account_id(programs::ping_sender().id())
     ));
     assert!(!is_sequencer_only_program(
-        program_program_loader_core::immutable_deploy_account_id(programs::clock().id())
+        program_loader_core::immutable_deploy_account_id(programs::clock().id())
     ));
 }
 
@@ -231,7 +231,7 @@ fn tx_is_bridge_deposit(
     };
 
     if public_tx.message.program_account_id
-        != program_program_loader_core::immutable_deploy_account_id(programs::bridge().id())
+        != program_loader_core::immutable_deploy_account_id(programs::bridge().id())
     {
         return false;
     }
@@ -261,7 +261,7 @@ fn cross_zone_test_config() -> SequencerConfig {
             peers: vec![CrossZonePeer {
                 channel_id: PEER_ZONE,
                 allowed_routes: vec![CrossZoneRoute {
-                    src_account_id: program_program_loader_core::immutable_deploy_account_id(
+                    src_account_id: program_loader_core::immutable_deploy_account_id(
                         programs::ping_sender().id(),
                     ),
                     target_program_id: programs::ping_receiver().id(),
@@ -299,7 +299,7 @@ fn dispatch_tx(src_block_id: u64, payload: Vec<u8>) -> LeeTransaction {
             src_block_id,
             src_block_hash: peer_block_hash(src_block_id),
             src_tx_index: 0,
-            src_account_id: program_program_loader_core::immutable_deploy_account_id(
+            src_account_id: program_loader_core::immutable_deploy_account_id(
                 programs::ping_sender().id(),
             ),
         },
@@ -1643,7 +1643,7 @@ async fn transactions_touching_clock_account_are_dropped_from_block() {
     // be dropped because their diffs touch the clock accounts.
     let crafted_clock_tx = {
         let message = lee::public_transaction::Message::try_new(
-            program_program_loader_core::immutable_deploy_account_id(programs::clock().id()),
+            program_loader_core::immutable_deploy_account_id(programs::clock().id()),
             system_accounts::clock_account_ids().to_vec(),
             vec![],
             42_u64,
@@ -2236,7 +2236,7 @@ fn resubmittable_txs_drops_clock_and_bridge_deposits() {
     .unwrap();
     let withdraw_tx = {
         let message = lee::public_transaction::Message::try_new(
-            program_program_loader_core::immutable_deploy_account_id(programs::bridge().id()),
+            program_loader_core::immutable_deploy_account_id(programs::bridge().id()),
             vec![system_accounts::bridge_account_id()],
             vec![],
             bridge_core::Instruction::Withdraw {
@@ -3192,13 +3192,13 @@ fn diag_sequencer_stake_claims_ownership_account() {
         .unwrap();
 
     let message = lee::public_transaction::Message::try_new(
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![funding_id, ownership_id, config_id],
         vec![Nonce(0), Nonce(0)],
         sequencer_stake_core::Instruction::Stake {
             sequencer_key,
             amount,
-            mover_account_id: program_program_loader_core::immutable_deploy_account_id(
+            mover_account_id: program_loader_core::immutable_deploy_account_id(
                 programs::authenticated_transfer().id(),
             ),
             mover_instruction_data,
@@ -3216,7 +3216,7 @@ fn diag_sequencer_stake_claims_ownership_account() {
     let ownership_account = state.get_account_by_id(ownership_id);
     assert_eq!(
         ownership_account.program_owner,
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         "ownership account should be claimed by sequencer_stake"
     );
     assert_eq!(ownership_account.balance, amount);
@@ -3240,7 +3240,7 @@ fn stake_transaction(
         .unwrap();
 
     let message = lee::public_transaction::Message::try_new(
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![
             funding_id,
             ownership_id,
@@ -3253,7 +3253,7 @@ fn stake_transaction(
         sequencer_stake_core::Instruction::Stake {
             sequencer_key,
             amount,
-            mover_account_id: program_program_loader_core::immutable_deploy_account_id(
+            mover_account_id: program_loader_core::immutable_deploy_account_id(
                 programs::authenticated_transfer().id(),
             ),
             mover_instruction_data,
@@ -3316,7 +3316,7 @@ fn unstake_request_transaction(
 ) -> PublicTransaction {
     let (ownership_id, ownership_key) = ownership;
     let message = lee::public_transaction::Message::try_new(
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![ownership_id, config_slot],
         vec![state.get_account_by_id(ownership_id).nonce],
         sequencer_stake_core::Instruction::UnstakeRequest {
@@ -3489,7 +3489,7 @@ fn an_ownership_account_cannot_stand_in_for_the_config_account() {
 
     assert_eq!(
         state.get_account_by_id(other_ownership_id).program_owner,
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         "the stand-in is owned by sequencer_stake, so ownership alone would not catch it"
     );
 
@@ -3554,7 +3554,7 @@ fn a_fully_exited_ownership_account_can_stake_again() {
 
     // Full exit, releasing back to the (now drained) funding account.
     let message = lee::public_transaction::Message::try_new(
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![
             ownership_id,
             system_accounts::sequencer_stake_config_account_id(),
@@ -3590,7 +3590,7 @@ fn a_fully_exited_ownership_account_can_stake_again() {
     assert_eq!(state.get_account_by_id(ownership_id).balance, 0);
     assert_eq!(
         state.get_account_by_id(ownership_id).program_owner,
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         "the ownership account stays claimed after a full exit"
     );
 
@@ -3623,7 +3623,7 @@ fn genesis_stakes_the_bootstrap_sequencer_at_the_configured_account() {
     let stake_account = state.get_account_by_id(bootstrap_stake_account_id(&config));
     assert_eq!(
         stake_account.program_owner,
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id())
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id())
     );
     assert_eq!(
         stake_account.balance,
@@ -3657,7 +3657,7 @@ fn the_bootstrap_sequencer_can_request_an_unstake_of_its_genesis_stake() {
     ));
 
     let message = lee::public_transaction::Message::try_new(
-        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![
             stake_id,
             system_accounts::sequencer_stake_config_account_id(),
@@ -3692,9 +3692,9 @@ fn the_bootstrap_sequencer_can_request_an_unstake_of_its_genesis_stake() {
 
 /// Derives the `(header, segments)` accounts `bytecode` would deploy to.
 fn deploy_targets(bytecode: &[u8]) -> (AccountId, Vec<AccountId>) {
-    let user_elf = program_program_loader_core::extract_user_elf(bytecode).unwrap();
-    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap();
-    let plan = program_program_loader_core::plan_deploy(
+    let user_elf = program_loader_core::extract_user_elf(bytecode).unwrap();
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let plan = program_loader_core::plan_deploy(
         RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
         image_id,
         AccountId::default(),
@@ -3719,8 +3719,8 @@ fn deploy_transaction(
     // and `compute_image_id` are best-effort here so malformed input still reaches
     // `execute_deploy`'s own rejection path, rather than this helper itself panicking first.
     let user_elf =
-        program_program_loader_core::extract_user_elf(bytecode).unwrap_or_else(|_| bytecode.to_vec());
-    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap_or([0; 8]);
+        program_loader_core::extract_user_elf(bytecode).unwrap_or_else(|_| bytecode.to_vec());
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap_or([0; 8]);
     let segment_count = u32::try_from(segments.len()).unwrap();
     deploy_batch_transaction(
         header,
@@ -3769,7 +3769,7 @@ fn deploy_batch_transaction(
         RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
         account_ids,
         nonces,
-        program_program_loader_core::Instruction::Deploy {
+        program_loader_core::Instruction::Deploy {
             image_id,
             segment_count,
             first_segment,
@@ -3817,7 +3817,12 @@ fn deploy_transactions(
                 )
             })
             .collect();
-        let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+        let header = program_loader_core::deploy_header_account_id(
+            RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+            image_id,
+            0,
+            update_auth,
+        );
         let batch_byte_len = batch_len
             .checked_mul(program_loader_core::MAX_SEGMENT_DATA_LEN)
             .unwrap()
@@ -3850,8 +3855,8 @@ fn loader_deploys_program() {
     let mut state = V03State::new();
 
     let bytecode = test_programs::claimer().elf().to_vec();
-    let user_elf = program_program_loader_core::extract_user_elf(&bytecode).unwrap();
-    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     let (header, segments) = deploy_targets(&bytecode);
 
     assert_eq!(state.get_account_by_id(header), Account::default());
@@ -3869,7 +3874,7 @@ fn loader_deploys_program() {
         deployed_header.program_owner,
         RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID
     );
-    let program_data = program_program_loader_core::ProgramData::try_from(&deployed_header.data)
+    let program_data = program_loader_core::ProgramData::try_from(&deployed_header.data)
         .expect("deployed header account data should decode as ProgramData");
     assert_eq!(program_data.image_id, image_id);
     assert_eq!(
@@ -3995,8 +4000,8 @@ fn loader_rejects_wrong_number_of_accounts() {
     let mut state = V03State::new();
 
     let bytecode = test_programs::claimer().elf().to_vec();
-    let user_elf = program_program_loader_core::extract_user_elf(&bytecode).unwrap();
-    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     let (header, segments) = deploy_targets(&bytecode);
     let extra = AccountId::new([9; 32]);
 
@@ -4008,7 +4013,7 @@ fn loader_rejects_wrong_number_of_accounts() {
         loader_id.into(),
         account_ids,
         vec![],
-        program_program_loader_core::Instruction::Deploy {
+        program_loader_core::Instruction::Deploy {
             image_id,
             segment_count: u32::try_from(segments.len()).unwrap(),
             first_segment: 0,
@@ -4043,9 +4048,21 @@ fn loader_deploys_program_across_multiple_transactions() {
     let key = PrivateKey::try_new([11; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
     let segment_ids: Vec<AccountId> = (0..segment_count)
-        .map(|i| program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, i, update_auth))
+        .map(|i| {
+            program_loader_core::deploy_segment_account_id(
+                RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+                image_id,
+                i,
+                update_auth,
+            )
+        })
         .collect();
 
     let remaining_segments = usize::try_from(segment_count.checked_sub(1).unwrap()).unwrap();
@@ -4092,9 +4109,21 @@ fn loader_deploy_batches_can_land_out_of_order() {
     let key = PrivateKey::try_new([12; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
     let segment_ids: Vec<AccountId> = (0..segment_count)
-        .map(|i| program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, i, update_auth))
+        .map(|i| {
+            program_loader_core::deploy_segment_account_id(
+                RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+                image_id,
+                i,
+                update_auth,
+            )
+        })
         .collect();
 
     // Batch covering segments [1..segment_count) lands first.
@@ -4158,7 +4187,12 @@ fn loader_get_program_returns_none_for_abandoned_multi_tx_deploy() {
     let txs = deploy_transactions(&bytecode, &[1, remaining_segments], update_auth, &key);
     let header = {
         let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-        program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth)
+        program_loader_core::deploy_header_account_id(
+            RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+            image_id,
+            0,
+            update_auth,
+        )
     };
 
     // Only the first batch ever lands — the deployer abandons the rest of the sequence.
@@ -4187,8 +4221,18 @@ fn loader_rejects_a_partial_deploy_batch_with_default_update_auth() {
 
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     let update_auth = AccountId::default();
-    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment0 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment0 = program_loader_core::deploy_segment_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
 
     // Genuinely partial (first_segment 0, but fewer segments than declared segment_count), and
     // no update_auth to fall back on — this is exactly the griefing shape the account list
@@ -4227,8 +4271,18 @@ fn loader_rejects_a_partial_deploy_batch_without_a_valid_signature() {
     let key = PrivateKey::try_new([14; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment0 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment0 = program_loader_core::deploy_segment_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
 
     // update_auth is real and declared correctly, but the transaction carries no witness for it.
     let tx = deploy_batch_transaction(
@@ -4267,9 +4321,24 @@ fn loader_rejects_header_racing_with_a_different_segment_count() {
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     // The header PDA depends on (image_id, update_auth) only, not on segment_count — verified
     // separately by header_pda_is_independent_of_segment_count in loader_core.
-    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment0 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment1 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 1, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment0 = program_loader_core::deploy_segment_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment1 = program_loader_core::deploy_segment_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        1,
+        update_auth,
+    );
 
     let tx1 = deploy_batch_transaction(
         header,
@@ -4322,8 +4391,18 @@ fn loader_rejects_overlapping_segment_rewrite() {
     let key = PrivateKey::try_new([16; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment0 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment0 = program_loader_core::deploy_segment_account_id(
+        RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
 
     let batch_bytes = &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())];
     let tx1 = deploy_batch_transaction(
@@ -4373,12 +4452,12 @@ fn loader_deploys_program_via_chained_call() {
     let mut state = V03State::new().with_programs([forwarder.clone()]);
 
     let bytecode = test_programs::claimer().elf().to_vec();
-    let user_elf = program_program_loader_core::extract_user_elf(&bytecode).unwrap();
-    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     let (header, segments) = deploy_targets(&bytecode);
 
     let inner_instruction_data =
-        lee::program::Program::serialize_instruction(program_program_loader_core::Instruction::Deploy {
+        lee::program::Program::serialize_instruction(program_loader_core::Instruction::Deploy {
             image_id,
             segment_count: u32::try_from(segments.len()).unwrap(),
             first_segment: 0,
@@ -4413,7 +4492,7 @@ fn loader_deploys_program_via_chained_call() {
         RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID
     );
 
-    let program_data = program_program_loader_core::ProgramData::try_from(&deployed_header.data)
+    let program_data = program_loader_core::ProgramData::try_from(&deployed_header.data)
         .expect("deployed header account data should decode as ProgramData");
     assert_eq!(program_data.image_id, image_id);
 

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -3703,31 +3703,143 @@ fn deploy_targets(bytecode: &[u8]) -> (AccountId, Vec<AccountId>) {
     )
 }
 
+/// Builds a single-transaction Deploy covering the whole of `bytecode`: `first_segment: 0`,
+/// declared `image_id`/`segment_count` derived honestly from the real bytes, no signer required
+/// (verified immediately against the real bytes by `execute_deploy`, not trusted).
 fn deploy_transaction(
     header: AccountId,
     segments: &[AccountId],
     bytecode: &[u8],
 ) -> PublicTransaction {
-    // Falls back to sending `bytecode` through unmodified when it isn't a well-formed two-ELF
-    // `ProgramBinary` (e.g. deliberately-garbage test input) — extraction is best-effort here so
-    // malformed input still reaches `execute_deploy`'s own rejection path, rather than the test
-    // helper itself panicking before the real system ever sees it.
+    // Falls back to sending `bytecode` through unmodified, and a dummy `image_id`, when it isn't
+    // a well-formed two-ELF `ProgramBinary` (e.g. deliberately-garbage test input) — extraction
+    // and `compute_image_id` are best-effort here so malformed input still reaches
+    // `execute_deploy`'s own rejection path, rather than this helper itself panicking first.
     let user_elf =
         program_loader_core::extract_user_elf(bytecode).unwrap_or_else(|_| bytecode.to_vec());
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap_or([0; 8]);
+    let segment_count = u32::try_from(segments.len()).unwrap();
+    deploy_batch_transaction(
+        header,
+        segments,
+        &user_elf,
+        image_id,
+        segment_count,
+        0,
+        AccountId::default(),
+        &[],
+        0,
+    )
+}
+
+/// Builds one transaction covering an arbitrary contiguous segment range of a (possibly
+/// multi-transaction) deploy. `signers` is the raw witness set — independent of what
+/// `update_auth` declares, so tests can exercise "declared but not signed" and "signed by the
+/// wrong key" alongside the happy path. `nonce` is every signer's current on-chain nonce — every
+/// signer here is at most a single reused `update_auth` key across a test, so one shared value is
+/// enough; callers reusing the same key across multiple transactions must bump it themselves
+/// (signing increments a signer's nonce regardless of whether the program writes to it).
+#[expect(
+    clippy::too_many_arguments,
+    reason = "test helper — grouping args would obscure intent"
+)]
+fn deploy_batch_transaction(
+    header: AccountId,
+    batch_segments: &[AccountId],
+    batch_user_elf: &[u8],
+    image_id: ProgramId,
+    segment_count: u32,
+    first_segment: u32,
+    update_auth: AccountId,
+    signers: &[&PrivateKey],
+    nonce: u128,
+) -> PublicTransaction {
+    let is_complete =
+        first_segment == 0 && u32::try_from(batch_segments.len()).unwrap() == segment_count;
     let mut account_ids = vec![header];
-    account_ids.extend_from_slice(segments);
+    if !is_complete {
+        account_ids.push(update_auth);
+    }
+    account_ids.extend_from_slice(batch_segments);
+    let nonces = signers.iter().map(|_| Nonce(nonce)).collect();
     let message = lee::public_transaction::Message::try_new(
         PROGRAM_LOADER_ACCOUNT_ID,
         account_ids,
-        vec![],
+        nonces,
         program_loader_core::Instruction::Deploy {
-            update_auth: AccountId::default(),
+            image_id,
+            segment_count,
+            first_segment,
+            update_auth,
         },
     )
     .unwrap()
-    .with_raw_payload(user_elf);
-    let witness_set = lee::public_transaction::WitnessSet::for_message(&message, &[]);
+    .with_raw_payload(batch_user_elf.to_vec());
+    let witness_set = lee::public_transaction::WitnessSet::for_message(&message, signers);
     PublicTransaction::new(message, witness_set)
+}
+
+/// Builds the full sequence of transactions a real multi-transaction deployer would send,
+/// partitioning `bytecode`'s segments per `batch_sizes` (in segments, not bytes). `update_auth`
+/// must be the `AccountId` corresponding to `signer`.
+fn deploy_transactions(
+    bytecode: &[u8],
+    batch_sizes: &[usize],
+    update_auth: AccountId,
+    signer: &PrivateKey,
+) -> Vec<PublicTransaction> {
+    let user_elf = program_loader_core::extract_user_elf(bytecode).unwrap();
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert_eq!(
+        batch_sizes.iter().sum::<usize>(),
+        usize::try_from(segment_count).unwrap(),
+        "batch_sizes must cover exactly segment_count segments"
+    );
+
+    let mut first_segment = 0_u32;
+    let mut byte_offset = 0_usize;
+    let mut transactions = Vec::with_capacity(batch_sizes.len());
+    for (nonce, &batch_len) in batch_sizes.iter().enumerate() {
+        let batch_segments: Vec<AccountId> = (0..batch_len)
+            .map(|i| {
+                let segment_number = first_segment
+                    .checked_add(u32::try_from(i).unwrap())
+                    .unwrap();
+                program_loader_core::deploy_segment_account_id(
+                    DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+                    image_id,
+                    segment_number,
+                    update_auth,
+                )
+            })
+            .collect();
+        let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+        let batch_byte_len = batch_len
+            .checked_mul(program_loader_core::MAX_SEGMENT_DATA_LEN)
+            .unwrap()
+            .min(user_elf.len().checked_sub(byte_offset).unwrap());
+        let batch_end = byte_offset.checked_add(batch_byte_len).unwrap();
+        let batch_user_elf = &user_elf[byte_offset..batch_end];
+
+        transactions.push(deploy_batch_transaction(
+            header,
+            &batch_segments,
+            batch_user_elf,
+            image_id,
+            segment_count,
+            first_segment,
+            update_auth,
+            &[signer],
+            u128::try_from(nonce).unwrap(),
+        ));
+
+        first_segment = first_segment
+            .checked_add(u32::try_from(batch_len).unwrap())
+            .unwrap();
+        byte_offset = batch_end;
+    }
+    transactions
 }
 
 #[test]
@@ -3874,6 +3986,8 @@ fn loader_rejects_wrong_number_of_accounts() {
     let mut state = V03State::new();
 
     let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     let (header, segments) = deploy_targets(&bytecode);
     let extra = AccountId::new([9; 32]);
 
@@ -3886,11 +4000,14 @@ fn loader_rejects_wrong_number_of_accounts() {
         account_ids,
         vec![],
         program_loader_core::Instruction::Deploy {
+            image_id,
+            segment_count: u32::try_from(segments.len()).unwrap(),
+            first_segment: 0,
             update_auth: AccountId::default(),
         },
     )
     .unwrap()
-    .with_raw_payload(bytecode);
+    .with_raw_payload(user_elf);
     let witness_set = lee::public_transaction::WitnessSet::for_message(&message, &[]);
     let tx = PublicTransaction::new(message, witness_set);
 
@@ -3899,6 +4016,340 @@ fn loader_rejects_wrong_number_of_accounts() {
     assert!(
         result.is_err(),
         "Deploying with the wrong number of accounts should fail, but got: {result:?}"
+    );
+}
+
+#[test]
+fn loader_deploys_program_across_multiple_transactions() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([11; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment_ids: Vec<AccountId> = (0..segment_count)
+        .map(|i| program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, i, update_auth))
+        .collect();
+
+    let remaining_segments = usize::try_from(segment_count.checked_sub(1).unwrap()).unwrap();
+    let txs = deploy_transactions(&bytecode, &[1, remaining_segments], update_auth, &key);
+    assert_eq!(txs.len(), 2);
+    for (i, tx) in txs.into_iter().enumerate() {
+        state
+            .transition_from_public_transaction(&tx, u64::try_from(i + 1).unwrap(), 0)
+            .unwrap_or_else(|e| panic!("batch {i} should succeed: {e:?}"));
+    }
+
+    let (deployed_image_id, reconstructed) = state
+        .get_program(header)
+        .unwrap()
+        .expect("both batches landed, program should be complete");
+    assert_eq!(deployed_image_id, image_id);
+    let deployed_header = state.get_account_by_id(header);
+    let program_data = program_loader_core::ProgramData::try_from(&deployed_header.data).unwrap();
+    assert_eq!(program_data.update_auth, update_auth);
+
+    let mut segments_concatenated = Vec::new();
+    for &segment in &segment_ids {
+        segments_concatenated.extend_from_slice(&state.get_account_by_id(segment).data);
+    }
+    assert_eq!(segments_concatenated, user_elf);
+    assert_eq!(
+        reconstructed,
+        program_loader_core::reconstruct_program_binary(&user_elf)
+    );
+}
+
+#[test]
+fn loader_deploy_batches_can_land_out_of_order() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([12; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment_ids: Vec<AccountId> = (0..segment_count)
+        .map(|i| program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, i, update_auth))
+        .collect();
+
+    // Batch covering segments [1..segment_count) lands first.
+    let tail_offset = program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len());
+    let tx_tail = deploy_batch_transaction(
+        header,
+        &segment_ids[1..],
+        &user_elf[tail_offset..],
+        image_id,
+        segment_count,
+        1,
+        update_auth,
+        &[&key],
+        0,
+    );
+    state
+        .transition_from_public_transaction(&tx_tail, 1, 0)
+        .expect("a later batch landing first should still succeed");
+
+    assert_eq!(
+        state.get_program(header).unwrap(),
+        None,
+        "program is incomplete until segment 0 lands too"
+    );
+
+    // Batch covering segment [0] lands second, completing the deploy.
+    let tx_head = deploy_batch_transaction(
+        header,
+        &segment_ids[..1],
+        &user_elf[..tail_offset],
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[&key],
+        1,
+    );
+    state
+        .transition_from_public_transaction(&tx_head, 2, 0)
+        .expect("completing batch should succeed");
+
+    assert!(state.get_program(header).unwrap().is_some());
+}
+
+#[test]
+fn loader_get_program_returns_none_for_abandoned_multi_tx_deploy() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([13; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+
+    let remaining_segments = usize::try_from(segment_count.checked_sub(1).unwrap()).unwrap();
+    let txs = deploy_transactions(&bytecode, &[1, remaining_segments], update_auth, &key);
+    let header = {
+        let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+        program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth)
+    };
+
+    // Only the first batch ever lands — the deployer abandons the rest of the sequence.
+    state
+        .transition_from_public_transaction(&txs[0], 1, 0)
+        .expect("first batch should succeed on its own");
+
+    assert_eq!(
+        state.get_program(header).unwrap(),
+        None,
+        "an abandoned multi-tx deploy must not be mistaken for a complete program"
+    );
+}
+
+#[test]
+fn loader_rejects_a_partial_deploy_batch_with_default_update_auth() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let update_auth = AccountId::default();
+    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+
+    // Genuinely partial (first_segment 0, but fewer segments than declared segment_count), and
+    // no update_auth to fall back on — this is exactly the griefing shape the account list
+    // conditional exists to block.
+    let tx = deploy_batch_transaction(
+        header,
+        &[segment0],
+        &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())],
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[],
+        0,
+    );
+    let result = state.transition_from_public_transaction(&tx, 1, 0);
+
+    assert!(
+        result.is_err(),
+        "a partial Deploy with a default update_auth should fail, but got: {result:?}"
+    );
+}
+
+#[test]
+fn loader_rejects_a_partial_deploy_batch_without_a_valid_signature() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([14; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+
+    // update_auth is real and declared correctly, but the transaction carries no witness for it.
+    let tx = deploy_batch_transaction(
+        header,
+        &[segment0],
+        &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())],
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[],
+        0,
+    );
+    let result = state.transition_from_public_transaction(&tx, 1, 0);
+
+    assert!(
+        result.is_err(),
+        "a partial Deploy without update_auth's signature should fail, but got: {result:?}"
+    );
+}
+
+#[test]
+fn loader_rejects_header_racing_with_a_different_segment_count() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([15; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    // The header PDA depends on (image_id, update_auth) only, not on segment_count — verified
+    // separately by header_pda_is_independent_of_segment_count in loader_core.
+    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment1 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 1, update_auth);
+
+    let tx1 = deploy_batch_transaction(
+        header,
+        &[segment0],
+        &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())],
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[&key],
+        0,
+    );
+    state
+        .transition_from_public_transaction(&tx1, 1, 0)
+        .expect("first batch should claim the header with segment_count segments declared");
+
+    // Same image_id and update_auth (same header address), but a different declared
+    // segment_count, targeting a fresh segment slot so only the header check is in play.
+    let tx2 = deploy_batch_transaction(
+        header,
+        &[segment1],
+        &user_elf[program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())..],
+        image_id,
+        segment_count + 1,
+        1,
+        update_auth,
+        &[&key],
+        1,
+    );
+    let result = state.transition_from_public_transaction(&tx2, 2, 0);
+
+    assert!(
+        result.is_err(),
+        "racing the same header with a different declared segment_count should fail, but got: {result:?}"
+    );
+}
+
+#[test]
+fn loader_rejects_overlapping_segment_rewrite() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([16; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+
+    let batch_bytes = &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())];
+    let tx1 = deploy_batch_transaction(
+        header,
+        &[segment0],
+        batch_bytes,
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[&key],
+        0,
+    );
+    state
+        .transition_from_public_transaction(&tx1, 1, 0)
+        .expect("first write to segment 0 should succeed");
+
+    // Same segment_count and update_auth (header re-claim is idempotently fine), but segment 0
+    // was already written — must be rejected regardless of the header being otherwise consistent.
+    let tx2 = deploy_batch_transaction(
+        header,
+        &[segment0],
+        batch_bytes,
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[&key],
+        1,
+    );
+    let result = state.transition_from_public_transaction(&tx2, 2, 0);
+
+    assert!(
+        result.is_err(),
+        "rewriting an already-written segment should fail, but got: {result:?}"
     );
 }
 
@@ -3919,6 +4370,9 @@ fn loader_deploys_program_via_chained_call() {
 
     let inner_instruction_data =
         lee::program::Program::serialize_instruction(program_loader_core::Instruction::Deploy {
+            image_id,
+            segment_count: u32::try_from(segments.len()).unwrap(),
+            first_segment: 0,
             update_auth: AccountId::default(),
         })
         .unwrap();

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -152,19 +152,19 @@ fn setup_sequencer_config() -> SequencerConfig {
 #[test]
 fn only_the_cross_zone_inbox_is_sequencer_only() {
     assert!(is_sequencer_only_program(
-        program_loader_core::immutable_deploy_account_id(programs::cross_zone_inbox().id())
+        program_program_loader_core::immutable_deploy_account_id(programs::cross_zone_inbox().id())
     ));
     assert!(!is_sequencer_only_program(
-        program_loader_core::immutable_deploy_account_id(programs::cross_zone_outbox().id())
+        program_program_loader_core::immutable_deploy_account_id(programs::cross_zone_outbox().id())
     ));
     assert!(!is_sequencer_only_program(
-        program_loader_core::immutable_deploy_account_id(programs::wrapped_token().id())
+        program_program_loader_core::immutable_deploy_account_id(programs::wrapped_token().id())
     ));
     assert!(!is_sequencer_only_program(
-        program_loader_core::immutable_deploy_account_id(programs::ping_sender().id())
+        program_program_loader_core::immutable_deploy_account_id(programs::ping_sender().id())
     ));
     assert!(!is_sequencer_only_program(
-        program_loader_core::immutable_deploy_account_id(programs::clock().id())
+        program_program_loader_core::immutable_deploy_account_id(programs::clock().id())
     ));
 }
 
@@ -231,7 +231,7 @@ fn tx_is_bridge_deposit(
     };
 
     if public_tx.message.program_account_id
-        != program_loader_core::immutable_deploy_account_id(programs::bridge().id())
+        != program_program_loader_core::immutable_deploy_account_id(programs::bridge().id())
     {
         return false;
     }
@@ -261,7 +261,7 @@ fn cross_zone_test_config() -> SequencerConfig {
             peers: vec![CrossZonePeer {
                 channel_id: PEER_ZONE,
                 allowed_routes: vec![CrossZoneRoute {
-                    src_account_id: program_loader_core::immutable_deploy_account_id(
+                    src_account_id: program_program_loader_core::immutable_deploy_account_id(
                         programs::ping_sender().id(),
                     ),
                     target_program_id: programs::ping_receiver().id(),
@@ -299,7 +299,7 @@ fn dispatch_tx(src_block_id: u64, payload: Vec<u8>) -> LeeTransaction {
             src_block_id,
             src_block_hash: peer_block_hash(src_block_id),
             src_tx_index: 0,
-            src_account_id: program_loader_core::immutable_deploy_account_id(
+            src_account_id: program_program_loader_core::immutable_deploy_account_id(
                 programs::ping_sender().id(),
             ),
         },
@@ -1643,7 +1643,7 @@ async fn transactions_touching_clock_account_are_dropped_from_block() {
     // be dropped because their diffs touch the clock accounts.
     let crafted_clock_tx = {
         let message = lee::public_transaction::Message::try_new(
-            program_loader_core::immutable_deploy_account_id(programs::clock().id()),
+            program_program_loader_core::immutable_deploy_account_id(programs::clock().id()),
             system_accounts::clock_account_ids().to_vec(),
             vec![],
             42_u64,
@@ -2236,7 +2236,7 @@ fn resubmittable_txs_drops_clock_and_bridge_deposits() {
     .unwrap();
     let withdraw_tx = {
         let message = lee::public_transaction::Message::try_new(
-            program_loader_core::immutable_deploy_account_id(programs::bridge().id()),
+            program_program_loader_core::immutable_deploy_account_id(programs::bridge().id()),
             vec![system_accounts::bridge_account_id()],
             vec![],
             bridge_core::Instruction::Withdraw {
@@ -3192,13 +3192,13 @@ fn diag_sequencer_stake_claims_ownership_account() {
         .unwrap();
 
     let message = lee::public_transaction::Message::try_new(
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![funding_id, ownership_id, config_id],
         vec![Nonce(0), Nonce(0)],
         sequencer_stake_core::Instruction::Stake {
             sequencer_key,
             amount,
-            mover_account_id: program_loader_core::immutable_deploy_account_id(
+            mover_account_id: program_program_loader_core::immutable_deploy_account_id(
                 programs::authenticated_transfer().id(),
             ),
             mover_instruction_data,
@@ -3216,7 +3216,7 @@ fn diag_sequencer_stake_claims_ownership_account() {
     let ownership_account = state.get_account_by_id(ownership_id);
     assert_eq!(
         ownership_account.program_owner,
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         "ownership account should be claimed by sequencer_stake"
     );
     assert_eq!(ownership_account.balance, amount);
@@ -3240,7 +3240,7 @@ fn stake_transaction(
         .unwrap();
 
     let message = lee::public_transaction::Message::try_new(
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![
             funding_id,
             ownership_id,
@@ -3253,7 +3253,7 @@ fn stake_transaction(
         sequencer_stake_core::Instruction::Stake {
             sequencer_key,
             amount,
-            mover_account_id: program_loader_core::immutable_deploy_account_id(
+            mover_account_id: program_program_loader_core::immutable_deploy_account_id(
                 programs::authenticated_transfer().id(),
             ),
             mover_instruction_data,
@@ -3316,7 +3316,7 @@ fn unstake_request_transaction(
 ) -> PublicTransaction {
     let (ownership_id, ownership_key) = ownership;
     let message = lee::public_transaction::Message::try_new(
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![ownership_id, config_slot],
         vec![state.get_account_by_id(ownership_id).nonce],
         sequencer_stake_core::Instruction::UnstakeRequest {
@@ -3489,7 +3489,7 @@ fn an_ownership_account_cannot_stand_in_for_the_config_account() {
 
     assert_eq!(
         state.get_account_by_id(other_ownership_id).program_owner,
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         "the stand-in is owned by sequencer_stake, so ownership alone would not catch it"
     );
 
@@ -3554,7 +3554,7 @@ fn a_fully_exited_ownership_account_can_stake_again() {
 
     // Full exit, releasing back to the (now drained) funding account.
     let message = lee::public_transaction::Message::try_new(
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![
             ownership_id,
             system_accounts::sequencer_stake_config_account_id(),
@@ -3590,7 +3590,7 @@ fn a_fully_exited_ownership_account_can_stake_again() {
     assert_eq!(state.get_account_by_id(ownership_id).balance, 0);
     assert_eq!(
         state.get_account_by_id(ownership_id).program_owner,
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         "the ownership account stays claimed after a full exit"
     );
 
@@ -3623,7 +3623,7 @@ fn genesis_stakes_the_bootstrap_sequencer_at_the_configured_account() {
     let stake_account = state.get_account_by_id(bootstrap_stake_account_id(&config));
     assert_eq!(
         stake_account.program_owner,
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id())
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id())
     );
     assert_eq!(
         stake_account.balance,
@@ -3657,7 +3657,7 @@ fn the_bootstrap_sequencer_can_request_an_unstake_of_its_genesis_stake() {
     ));
 
     let message = lee::public_transaction::Message::try_new(
-        program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
+        program_program_loader_core::immutable_deploy_account_id(programs::sequencer_stake().id()),
         vec![
             stake_id,
             system_accounts::sequencer_stake_config_account_id(),
@@ -3692,9 +3692,9 @@ fn the_bootstrap_sequencer_can_request_an_unstake_of_its_genesis_stake() {
 
 /// Derives the `(header, segments)` accounts `bytecode` would deploy to.
 fn deploy_targets(bytecode: &[u8]) -> (AccountId, Vec<AccountId>) {
-    let user_elf = program_loader_core::extract_user_elf(bytecode).unwrap();
-    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let plan = program_loader_core::plan_deploy(
+    let user_elf = program_program_loader_core::extract_user_elf(bytecode).unwrap();
+    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap();
+    let plan = program_program_loader_core::plan_deploy(
         RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
         image_id,
         AccountId::default(),
@@ -3706,31 +3706,143 @@ fn deploy_targets(bytecode: &[u8]) -> (AccountId, Vec<AccountId>) {
     )
 }
 
+/// Builds a single-transaction Deploy covering the whole of `bytecode`: `first_segment: 0`,
+/// declared `image_id`/`segment_count` derived honestly from the real bytes, no signer required
+/// (verified immediately against the real bytes by `execute_deploy`, not trusted).
 fn deploy_transaction(
     header: AccountId,
     segments: &[AccountId],
     bytecode: &[u8],
 ) -> PublicTransaction {
-    // Falls back to sending `bytecode` through unmodified when it isn't a well-formed two-ELF
-    // `ProgramBinary` (e.g. deliberately-garbage test input) — extraction is best-effort here so
-    // malformed input still reaches `execute_deploy`'s own rejection path, rather than the test
-    // helper itself panicking before the real system ever sees it.
+    // Falls back to sending `bytecode` through unmodified, and a dummy `image_id`, when it isn't
+    // a well-formed two-ELF `ProgramBinary` (e.g. deliberately-garbage test input) — extraction
+    // and `compute_image_id` are best-effort here so malformed input still reaches
+    // `execute_deploy`'s own rejection path, rather than this helper itself panicking first.
     let user_elf =
-        program_loader_core::extract_user_elf(bytecode).unwrap_or_else(|_| bytecode.to_vec());
+        program_program_loader_core::extract_user_elf(bytecode).unwrap_or_else(|_| bytecode.to_vec());
+    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap_or([0; 8]);
+    let segment_count = u32::try_from(segments.len()).unwrap();
+    deploy_batch_transaction(
+        header,
+        segments,
+        &user_elf,
+        image_id,
+        segment_count,
+        0,
+        AccountId::default(),
+        &[],
+        0,
+    )
+}
+
+/// Builds one transaction covering an arbitrary contiguous segment range of a (possibly
+/// multi-transaction) deploy. `signers` is the raw witness set — independent of what
+/// `update_auth` declares, so tests can exercise "declared but not signed" and "signed by the
+/// wrong key" alongside the happy path. `nonce` is every signer's current on-chain nonce — every
+/// signer here is at most a single reused `update_auth` key across a test, so one shared value is
+/// enough; callers reusing the same key across multiple transactions must bump it themselves
+/// (signing increments a signer's nonce regardless of whether the program writes to it).
+#[expect(
+    clippy::too_many_arguments,
+    reason = "test helper — grouping args would obscure intent"
+)]
+fn deploy_batch_transaction(
+    header: AccountId,
+    batch_segments: &[AccountId],
+    batch_user_elf: &[u8],
+    image_id: ProgramId,
+    segment_count: u32,
+    first_segment: u32,
+    update_auth: AccountId,
+    signers: &[&PrivateKey],
+    nonce: u128,
+) -> PublicTransaction {
+    let is_complete =
+        first_segment == 0 && u32::try_from(batch_segments.len()).unwrap() == segment_count;
     let mut account_ids = vec![header];
-    account_ids.extend_from_slice(segments);
+    if !is_complete {
+        account_ids.push(update_auth);
+    }
+    account_ids.extend_from_slice(batch_segments);
+    let nonces = signers.iter().map(|_| Nonce(nonce)).collect();
     let message = lee::public_transaction::Message::try_new(
         RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
         account_ids,
-        vec![],
-        program_loader_core::Instruction::Deploy {
-            update_auth: AccountId::default(),
+        nonces,
+        program_program_loader_core::Instruction::Deploy {
+            image_id,
+            segment_count,
+            first_segment,
+            update_auth,
         },
     )
     .unwrap()
-    .with_raw_payload(user_elf);
-    let witness_set = lee::public_transaction::WitnessSet::for_message(&message, &[]);
+    .with_raw_payload(batch_user_elf.to_vec());
+    let witness_set = lee::public_transaction::WitnessSet::for_message(&message, signers);
     PublicTransaction::new(message, witness_set)
+}
+
+/// Builds the full sequence of transactions a real multi-transaction deployer would send,
+/// partitioning `bytecode`'s segments per `batch_sizes` (in segments, not bytes). `update_auth`
+/// must be the `AccountId` corresponding to `signer`.
+fn deploy_transactions(
+    bytecode: &[u8],
+    batch_sizes: &[usize],
+    update_auth: AccountId,
+    signer: &PrivateKey,
+) -> Vec<PublicTransaction> {
+    let user_elf = program_loader_core::extract_user_elf(bytecode).unwrap();
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert_eq!(
+        batch_sizes.iter().sum::<usize>(),
+        usize::try_from(segment_count).unwrap(),
+        "batch_sizes must cover exactly segment_count segments"
+    );
+
+    let mut first_segment = 0_u32;
+    let mut byte_offset = 0_usize;
+    let mut transactions = Vec::with_capacity(batch_sizes.len());
+    for (nonce, &batch_len) in batch_sizes.iter().enumerate() {
+        let batch_segments: Vec<AccountId> = (0..batch_len)
+            .map(|i| {
+                let segment_number = first_segment
+                    .checked_add(u32::try_from(i).unwrap())
+                    .unwrap();
+                program_loader_core::deploy_segment_account_id(
+                    RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+                    image_id,
+                    segment_number,
+                    update_auth,
+                )
+            })
+            .collect();
+        let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+        let batch_byte_len = batch_len
+            .checked_mul(program_loader_core::MAX_SEGMENT_DATA_LEN)
+            .unwrap()
+            .min(user_elf.len().checked_sub(byte_offset).unwrap());
+        let batch_end = byte_offset.checked_add(batch_byte_len).unwrap();
+        let batch_user_elf = &user_elf[byte_offset..batch_end];
+
+        transactions.push(deploy_batch_transaction(
+            header,
+            &batch_segments,
+            batch_user_elf,
+            image_id,
+            segment_count,
+            first_segment,
+            update_auth,
+            &[signer],
+            u128::try_from(nonce).unwrap(),
+        ));
+
+        first_segment = first_segment
+            .checked_add(u32::try_from(batch_len).unwrap())
+            .unwrap();
+        byte_offset = batch_end;
+    }
+    transactions
 }
 
 #[test]
@@ -3738,8 +3850,8 @@ fn loader_deploys_program() {
     let mut state = V03State::new();
 
     let bytecode = test_programs::claimer().elf().to_vec();
-    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
-    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let user_elf = program_program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap();
     let (header, segments) = deploy_targets(&bytecode);
 
     assert_eq!(state.get_account_by_id(header), Account::default());
@@ -3757,7 +3869,7 @@ fn loader_deploys_program() {
         deployed_header.program_owner,
         RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID
     );
-    let program_data = program_loader_core::ProgramData::try_from(&deployed_header.data)
+    let program_data = program_program_loader_core::ProgramData::try_from(&deployed_header.data)
         .expect("deployed header account data should decode as ProgramData");
     assert_eq!(program_data.image_id, image_id);
     assert_eq!(
@@ -3883,6 +3995,8 @@ fn loader_rejects_wrong_number_of_accounts() {
     let mut state = V03State::new();
 
     let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap();
     let (header, segments) = deploy_targets(&bytecode);
     let extra = AccountId::new([9; 32]);
 
@@ -3894,12 +4008,15 @@ fn loader_rejects_wrong_number_of_accounts() {
         loader_id.into(),
         account_ids,
         vec![],
-        program_loader_core::Instruction::Deploy {
+        program_program_loader_core::Instruction::Deploy {
+            image_id,
+            segment_count: u32::try_from(segments.len()).unwrap(),
+            first_segment: 0,
             update_auth: AccountId::default(),
         },
     )
     .unwrap()
-    .with_raw_payload(bytecode);
+    .with_raw_payload(user_elf);
     let witness_set = lee::public_transaction::WitnessSet::for_message(&message, &[]);
     let tx = PublicTransaction::new(message, witness_set);
 
@@ -3908,6 +4025,340 @@ fn loader_rejects_wrong_number_of_accounts() {
     assert!(
         result.is_err(),
         "Deploying with the wrong number of accounts should fail, but got: {result:?}"
+    );
+}
+
+#[test]
+fn loader_deploys_program_across_multiple_transactions() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([11; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment_ids: Vec<AccountId> = (0..segment_count)
+        .map(|i| program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, i, update_auth))
+        .collect();
+
+    let remaining_segments = usize::try_from(segment_count.checked_sub(1).unwrap()).unwrap();
+    let txs = deploy_transactions(&bytecode, &[1, remaining_segments], update_auth, &key);
+    assert_eq!(txs.len(), 2);
+    for (i, tx) in txs.into_iter().enumerate() {
+        state
+            .transition_from_public_transaction(&tx, u64::try_from(i + 1).unwrap(), 0)
+            .unwrap_or_else(|e| panic!("batch {i} should succeed: {e:?}"));
+    }
+
+    let (deployed_image_id, reconstructed) = state
+        .get_program(header)
+        .unwrap()
+        .expect("both batches landed, program should be complete");
+    assert_eq!(deployed_image_id, image_id);
+    let deployed_header = state.get_account_by_id(header);
+    let program_data = program_loader_core::ProgramData::try_from(&deployed_header.data).unwrap();
+    assert_eq!(program_data.update_auth, update_auth);
+
+    let mut segments_concatenated = Vec::new();
+    for &segment in &segment_ids {
+        segments_concatenated.extend_from_slice(&state.get_account_by_id(segment).data);
+    }
+    assert_eq!(segments_concatenated, user_elf);
+    assert_eq!(
+        reconstructed,
+        program_loader_core::reconstruct_program_binary(&user_elf)
+    );
+}
+
+#[test]
+fn loader_deploy_batches_can_land_out_of_order() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([12; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment_ids: Vec<AccountId> = (0..segment_count)
+        .map(|i| program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, i, update_auth))
+        .collect();
+
+    // Batch covering segments [1..segment_count) lands first.
+    let tail_offset = program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len());
+    let tx_tail = deploy_batch_transaction(
+        header,
+        &segment_ids[1..],
+        &user_elf[tail_offset..],
+        image_id,
+        segment_count,
+        1,
+        update_auth,
+        &[&key],
+        0,
+    );
+    state
+        .transition_from_public_transaction(&tx_tail, 1, 0)
+        .expect("a later batch landing first should still succeed");
+
+    assert_eq!(
+        state.get_program(header).unwrap(),
+        None,
+        "program is incomplete until segment 0 lands too"
+    );
+
+    // Batch covering segment [0] lands second, completing the deploy.
+    let tx_head = deploy_batch_transaction(
+        header,
+        &segment_ids[..1],
+        &user_elf[..tail_offset],
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[&key],
+        1,
+    );
+    state
+        .transition_from_public_transaction(&tx_head, 2, 0)
+        .expect("completing batch should succeed");
+
+    assert!(state.get_program(header).unwrap().is_some());
+}
+
+#[test]
+fn loader_get_program_returns_none_for_abandoned_multi_tx_deploy() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([13; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+
+    let remaining_segments = usize::try_from(segment_count.checked_sub(1).unwrap()).unwrap();
+    let txs = deploy_transactions(&bytecode, &[1, remaining_segments], update_auth, &key);
+    let header = {
+        let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+        program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth)
+    };
+
+    // Only the first batch ever lands — the deployer abandons the rest of the sequence.
+    state
+        .transition_from_public_transaction(&txs[0], 1, 0)
+        .expect("first batch should succeed on its own");
+
+    assert_eq!(
+        state.get_program(header).unwrap(),
+        None,
+        "an abandoned multi-tx deploy must not be mistaken for a complete program"
+    );
+}
+
+#[test]
+fn loader_rejects_a_partial_deploy_batch_with_default_update_auth() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let update_auth = AccountId::default();
+    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+
+    // Genuinely partial (first_segment 0, but fewer segments than declared segment_count), and
+    // no update_auth to fall back on — this is exactly the griefing shape the account list
+    // conditional exists to block.
+    let tx = deploy_batch_transaction(
+        header,
+        &[segment0],
+        &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())],
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[],
+        0,
+    );
+    let result = state.transition_from_public_transaction(&tx, 1, 0);
+
+    assert!(
+        result.is_err(),
+        "a partial Deploy with a default update_auth should fail, but got: {result:?}"
+    );
+}
+
+#[test]
+fn loader_rejects_a_partial_deploy_batch_without_a_valid_signature() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([14; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+
+    // update_auth is real and declared correctly, but the transaction carries no witness for it.
+    let tx = deploy_batch_transaction(
+        header,
+        &[segment0],
+        &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())],
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[],
+        0,
+    );
+    let result = state.transition_from_public_transaction(&tx, 1, 0);
+
+    assert!(
+        result.is_err(),
+        "a partial Deploy without update_auth's signature should fail, but got: {result:?}"
+    );
+}
+
+#[test]
+fn loader_rejects_header_racing_with_a_different_segment_count() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([15; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    // The header PDA depends on (image_id, update_auth) only, not on segment_count — verified
+    // separately by header_pda_is_independent_of_segment_count in loader_core.
+    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment1 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 1, update_auth);
+
+    let tx1 = deploy_batch_transaction(
+        header,
+        &[segment0],
+        &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())],
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[&key],
+        0,
+    );
+    state
+        .transition_from_public_transaction(&tx1, 1, 0)
+        .expect("first batch should claim the header with segment_count segments declared");
+
+    // Same image_id and update_auth (same header address), but a different declared
+    // segment_count, targeting a fresh segment slot so only the header check is in play.
+    let tx2 = deploy_batch_transaction(
+        header,
+        &[segment1],
+        &user_elf[program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())..],
+        image_id,
+        segment_count + 1,
+        1,
+        update_auth,
+        &[&key],
+        1,
+    );
+    let result = state.transition_from_public_transaction(&tx2, 2, 0);
+
+    assert!(
+        result.is_err(),
+        "racing the same header with a different declared segment_count should fail, but got: {result:?}"
+    );
+}
+
+#[test]
+fn loader_rejects_overlapping_segment_rewrite() {
+    let mut state = V03State::new();
+
+    let bytecode = test_programs::claimer().elf().to_vec();
+    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let segment_count = program_loader_core::segment_count_for(&user_elf);
+    assert!(
+        segment_count >= 2,
+        "test assumes claimer spans multiple segments"
+    );
+
+    let key = PrivateKey::try_new([16; 32]).unwrap();
+    let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
+    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let header = program_loader_core::deploy_header_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let segment0 = program_loader_core::deploy_segment_account_id(RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+
+    let batch_bytes = &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())];
+    let tx1 = deploy_batch_transaction(
+        header,
+        &[segment0],
+        batch_bytes,
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[&key],
+        0,
+    );
+    state
+        .transition_from_public_transaction(&tx1, 1, 0)
+        .expect("first write to segment 0 should succeed");
+
+    // Same segment_count and update_auth (header re-claim is idempotently fine), but segment 0
+    // was already written — must be rejected regardless of the header being otherwise consistent.
+    let tx2 = deploy_batch_transaction(
+        header,
+        &[segment0],
+        batch_bytes,
+        image_id,
+        segment_count,
+        0,
+        update_auth,
+        &[&key],
+        1,
+    );
+    let result = state.transition_from_public_transaction(&tx2, 2, 0);
+
+    assert!(
+        result.is_err(),
+        "rewriting an already-written segment should fail, but got: {result:?}"
     );
 }
 
@@ -3922,12 +4373,15 @@ fn loader_deploys_program_via_chained_call() {
     let mut state = V03State::new().with_programs([forwarder.clone()]);
 
     let bytecode = test_programs::claimer().elf().to_vec();
-    let user_elf = program_loader_core::extract_user_elf(&bytecode).unwrap();
-    let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
+    let user_elf = program_program_loader_core::extract_user_elf(&bytecode).unwrap();
+    let image_id = program_program_loader_core::compute_image_id(&user_elf).unwrap();
     let (header, segments) = deploy_targets(&bytecode);
 
     let inner_instruction_data =
-        lee::program::Program::serialize_instruction(program_loader_core::Instruction::Deploy {
+        lee::program::Program::serialize_instruction(program_program_loader_core::Instruction::Deploy {
+            image_id,
+            segment_count: u32::try_from(segments.len()).unwrap(),
+            first_segment: 0,
             update_auth: AccountId::default(),
         })
         .unwrap();
@@ -3959,7 +4413,7 @@ fn loader_deploys_program_via_chained_call() {
         RESERVED_DEPLOYMENT_PROGRAM_ACCOUNT_ID
     );
 
-    let program_data = program_loader_core::ProgramData::try_from(&deployed_header.data)
+    let program_data = program_program_loader_core::ProgramData::try_from(&deployed_header.data)
         .expect("deployed header account data should decode as ProgramData");
     assert_eq!(program_data.image_id, image_id);
 

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -3814,7 +3814,12 @@ fn deploy_transactions(
                 )
             })
             .collect();
-        let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+        let header = program_loader_core::deploy_header_account_id(
+            DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+            image_id,
+            0,
+            update_auth,
+        );
         let batch_byte_len = batch_len
             .checked_mul(program_loader_core::MAX_SEGMENT_DATA_LEN)
             .unwrap()
@@ -4034,9 +4039,21 @@ fn loader_deploys_program_across_multiple_transactions() {
     let key = PrivateKey::try_new([11; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
     let segment_ids: Vec<AccountId> = (0..segment_count)
-        .map(|i| program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, i, update_auth))
+        .map(|i| {
+            program_loader_core::deploy_segment_account_id(
+                DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+                image_id,
+                i,
+                update_auth,
+            )
+        })
         .collect();
 
     let remaining_segments = usize::try_from(segment_count.checked_sub(1).unwrap()).unwrap();
@@ -4083,9 +4100,21 @@ fn loader_deploy_batches_can_land_out_of_order() {
     let key = PrivateKey::try_new([12; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
     let segment_ids: Vec<AccountId> = (0..segment_count)
-        .map(|i| program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, i, update_auth))
+        .map(|i| {
+            program_loader_core::deploy_segment_account_id(
+                DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+                image_id,
+                i,
+                update_auth,
+            )
+        })
         .collect();
 
     // Batch covering segments [1..segment_count) lands first.
@@ -4149,7 +4178,12 @@ fn loader_get_program_returns_none_for_abandoned_multi_tx_deploy() {
     let txs = deploy_transactions(&bytecode, &[1, remaining_segments], update_auth, &key);
     let header = {
         let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-        program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth)
+        program_loader_core::deploy_header_account_id(
+            DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+            image_id,
+            0,
+            update_auth,
+        )
     };
 
     // Only the first batch ever lands — the deployer abandons the rest of the sequence.
@@ -4178,8 +4212,18 @@ fn loader_rejects_a_partial_deploy_batch_with_default_update_auth() {
 
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     let update_auth = AccountId::default();
-    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment0 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment0 = program_loader_core::deploy_segment_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
 
     // Genuinely partial (first_segment 0, but fewer segments than declared segment_count), and
     // no update_auth to fall back on — this is exactly the griefing shape the account list
@@ -4218,8 +4262,18 @@ fn loader_rejects_a_partial_deploy_batch_without_a_valid_signature() {
     let key = PrivateKey::try_new([14; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment0 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment0 = program_loader_core::deploy_segment_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
 
     // update_auth is real and declared correctly, but the transaction carries no witness for it.
     let tx = deploy_batch_transaction(
@@ -4258,9 +4312,24 @@ fn loader_rejects_header_racing_with_a_different_segment_count() {
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
     // The header PDA depends on (image_id, update_auth) only, not on segment_count — verified
     // separately by header_pda_is_independent_of_segment_count in loader_core.
-    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment0 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment1 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 1, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment0 = program_loader_core::deploy_segment_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment1 = program_loader_core::deploy_segment_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        1,
+        update_auth,
+    );
 
     let tx1 = deploy_batch_transaction(
         header,
@@ -4313,8 +4382,18 @@ fn loader_rejects_overlapping_segment_rewrite() {
     let key = PrivateKey::try_new([16; 32]).unwrap();
     let update_auth = AccountId::from(&PublicKey::new_from_private_key(&key));
     let image_id = program_loader_core::compute_image_id(&user_elf).unwrap();
-    let header = program_loader_core::deploy_header_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
-    let segment0 = program_loader_core::deploy_segment_account_id(DEPLOYMENT_PROGRAM_ACCOUNT_ID, image_id, 0, update_auth);
+    let header = program_loader_core::deploy_header_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
+    let segment0 = program_loader_core::deploy_segment_account_id(
+        DEPLOYMENT_PROGRAM_ACCOUNT_ID,
+        image_id,
+        0,
+        update_auth,
+    );
 
     let batch_bytes = &user_elf[..program_loader_core::MAX_SEGMENT_DATA_LEN.min(user_elf.len())];
     let tx1 = deploy_batch_transaction(


### PR DESCRIPTION
## 🎯 Purpose

This PR continues programs as accounts, and programs deployable through public transactions. In [PR 740](https://github.com/logos-blockchain/logos-execution-zone/pull/740) required a `Deploy`'s whole payload to land in a single transaction; single transaction deploys all of the segmented PDAs for the program. This PR allows a program to be deployed across multiple transactions.

## ⚙️ Approach

- [X] `image_id` and `segment_count` become caller-declared fields on `Instruction::Deploy`, alongside a new `first_segment` marking where this transaction's segment range starts.
- [X] Verified immediately when a transaction is self-contained (`first_segment == 0` and it covers every declared segment) — unchanged safety from the single-transaction case, no signature required.
- [X] A genuine partial batch can't verify `image_id`/`segment_count` from what it alone carries, so it must instead prove control of `update_auth` via a real signature (a second `pre_states` entry, `is_authorized`) — closing the header-squatting window a caller-declared `image_id` would otherwise reopen. `V03State::get_program` catches any eventual mismatch lazily, once every segment exists.
- [X] The header target may be `Account::default()` (starting a new deployment) or already exactly this deployment's header (continuing one); every other target must be untouched, since each segment is written exactly once.
- [X] `program_loader_core::plan_deploy` becomes the `first_segment: 0`, whole-program special case of the new `plan_deploy_range`, so single-transaction and multi-transaction deploys share the same chunking logic.

## 🧪 How to Test

16 new tests were added for batched/partial deployment:

`lez/programs/program_loader/core/src/lib.rs` — `execute_deploy`'s batch-acceptance and rejection paths:
- `execute_deploy_single_batch_still_works`
- `execute_deploy_two_batch_sequence_succeeds`
- `execute_deploy_rejects_a_partial_batch_with_default_update_auth`
- `execute_deploy_rejects_a_partial_batch_without_update_auths_signature`
- `execute_deploy_rejects_batch_past_declared_segment_count`
- `execute_deploy_rejects_header_only_batch`
- `execute_deploy_rejects_rewriting_a_written_segment`
- `execute_deploy_rejects_a_complete_batch_with_a_dishonest_image_id`
- `plan_deploy_range_batches_reassemble_to_the_same_plan`

`lez/sequencer/core/src/tests.rs` — end-to-end multi-transaction deploys through `V03State`:
- `loader_deploys_program_across_multiple_transactions`
- `loader_deploy_batches_can_land_out_of_order`
- `loader_get_program_returns_none_for_abandoned_multi_tx_deploy`
- `loader_rejects_a_partial_deploy_batch_with_default_update_auth`
- `loader_rejects_a_partial_deploy_batch_without_a_valid_signature`
- `loader_rejects_header_racing_with_a_different_segment_count`
- `loader_rejects_overlapping_segment_rewrite`

## 🔗 Dependencies
Builds off of [PR 740](https://github.com/logos-blockchain/logos-execution-zone/pull/740).

## 🔜 Future Work

- Clean up; complete removal of `ProgramId` and `ProgramDeploymentTransaction`.
- Program upgradeability.

## 📋 PR Completion Checklist

- [X] Complete PR description
- [X] Implement the core functionality
- [X] Add/update tests
- [ ] Add/update documentation and inline comments
