### PR TITLE
feat(fees): cycle-count metering for public execution

### DIFF
--- a/lee/state_machine/core/src/account.rs
+++ b/lee/state_machine/core/src/account.rs
@@ -90,8 +90,10 @@ pub type Balance = u128;
 /// A base-fee price or tip, in atomic units; fits `u64` by the per-block gas caps
 /// (balances and totals are [`Balance`], `u128`).
 pub type Fee = u64;
-/// A gas amount — execution or storage work, bounded per block.
+/// A gas amount (execution or storage work), bounded per block.
 pub type Gas = u64;
+/// A raw zkVM execution cycle count or budget, before it is priced into [`Gas`].
+pub type Cycles = u64;
 
 /// Account to be used both in public and private contexts.
 #[derive(

--- a/lee/state_machine/src/error.rs
+++ b/lee/state_machine/src/error.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use lee_core::{
-    account::{Account, AccountId},
+    account::{Account, AccountId, Cycles},
     program::ProgramId,
 };
 use thiserror::Error;
@@ -21,7 +21,7 @@ pub enum LeeError {
     InvalidInput(String),
 
     #[error("Execution exceeded its cycle budget of {budget} cycles")]
-    OutOfGas { budget: u64 },
+    OutOfGas { budget: Cycles },
 
     #[error("Program violated execution rules")]
     InvalidProgramBehavior(#[from] InvalidProgramBehaviorError),

--- a/lee/state_machine/src/error.rs
+++ b/lee/state_machine/src/error.rs
@@ -20,6 +20,9 @@ pub enum LeeError {
     #[error("Invalid input: {0}")]
     InvalidInput(String),
 
+    #[error("Execution exceeded its cycle budget of {budget}")]
+    OutOfGas { budget: u64 },
+
     #[error("Program violated execution rules")]
     InvalidProgramBehavior(#[from] InvalidProgramBehaviorError),
 

--- a/lee/state_machine/src/error.rs
+++ b/lee/state_machine/src/error.rs
@@ -20,7 +20,7 @@ pub enum LeeError {
     #[error("Invalid input: {0}")]
     InvalidInput(String),
 
-    #[error("Execution exceeded its cycle budget of {budget}")]
+    #[error("Execution exceeded its cycle budget of {budget} cycles")]
     OutOfGas { budget: u64 },
 
     #[error("Program violated execution rules")]

--- a/lee/state_machine/src/lib.rs
+++ b/lee/state_machine/src/lib.rs
@@ -6,7 +6,7 @@
 pub use fees::{FeeDeclaration, SignedMessage, is_fee_authorized};
 pub use lee_core::{
     GENESIS_BLOCK_ID, SharedSecretKey,
-    account::{Account, AccountId, Balance, Data, Fee, Gas},
+    account::{Account, AccountId, Balance, Cycles, Data, Fee, Gas},
     encryption::EphemeralPublicKey,
     program::ProgramId,
 };

--- a/lee/state_machine/src/lib.rs
+++ b/lee/state_machine/src/lib.rs
@@ -20,7 +20,7 @@ pub use program_deployment_transaction::ProgramDeploymentTransaction;
 pub use public_transaction::PublicTransaction;
 pub use signature::{PrivateKey, PublicKey, Signature};
 pub use state::V03State;
-pub use validated_state_diff::ValidatedStateDiff;
+pub use validated_state_diff::{ExecutionOutcome, ValidatedStateDiff};
 
 pub mod encoding;
 pub mod error;

--- a/lee/state_machine/src/program/mod.rs
+++ b/lee/state_machine/src/program/mod.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use lee_core::{
-    account::AccountWithMetadata,
+    account::{AccountWithMetadata, Cycles},
     from_frame,
     program::{InstructionData, ProgramId, ProgramInput, ProgramOutput},
     to_frame,
@@ -14,7 +14,7 @@ use crate::error::LeeError;
 /// The cycle budget applied to public execution paths that do not yet carry
 /// a transaction-specific budget. Enforcement of the fee spec's per-block cap
 /// replaces this in the charging transition.
-pub const DEFAULT_PUBLIC_CYCLE_BUDGET: u64 = 1024 * 1024 * 32; // 32M cycles
+pub const DEFAULT_PUBLIC_CYCLE_BUDGET: Cycles = 1024 * 1024 * 32; // 32M cycles
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Program {
@@ -60,8 +60,8 @@ impl Program {
         caller_program_id: Option<ProgramId>,
         pre_states: &[AccountWithMetadata],
         instruction_data: &InstructionData,
-        cycle_budget: u64,
-    ) -> Result<(ProgramOutput, u64), LeeError> {
+        cycle_budget: Cycles,
+    ) -> Result<(ProgramOutput, Cycles), LeeError> {
         // Write inputs to the program
         let mut env_builder = ExecutorEnv::builder();
         env_builder.session_limit(Some(cycle_budget));
@@ -95,7 +95,7 @@ impl Program {
     fn execute_session(
         env: ExecutorEnv<'_>,
         elf: &[u8],
-        cycle_budget: u64,
+        cycle_budget: Cycles,
     ) -> Result<risc0_zkvm::SessionInfo, LeeError> {
         default_executor().execute(env, elf).map_err(|e| {
             // check for "Guest panicked" to prevent spoofing

--- a/lee/state_machine/src/program/mod.rs
+++ b/lee/state_machine/src/program/mod.rs
@@ -91,14 +91,17 @@ impl Program {
     /// typed [`LeeError::OutOfGas`]. The only place that error string is
     /// recognized.
     ///
-    /// FIXME: This is a brittle string match; the executor should provide a typed error
+    /// FIXME: This is a brittle string match; the executor should provide a typed error.
     fn execute_session(
         env: ExecutorEnv<'_>,
         elf: &[u8],
         cycle_budget: u64,
     ) -> Result<risc0_zkvm::SessionInfo, LeeError> {
         default_executor().execute(env, elf).map_err(|e| {
-            if format!("{e:#}").contains("Session limit exceeded") {
+            // check for "Guest panicked" to prevent spoofing
+            // via `panic!("Session limit exceeded")` cases
+            let message = format!("{e:#}");
+            if message.contains("Session limit exceeded") && !message.contains("Guest panicked") {
                 LeeError::OutOfGas {
                     budget: cycle_budget,
                 }

--- a/lee/state_machine/src/program/mod.rs
+++ b/lee/state_machine/src/program/mod.rs
@@ -11,9 +11,10 @@ use risc0_zkvm::{ExecutorEnv, ExecutorEnvBuilder, default_executor};
 
 use crate::error::LeeError;
 
-/// Maximum number of cycles for a public execution.
-/// TODO: Make this variable when fees are implemented.
-const MAX_NUM_CYCLES_PUBLIC_EXECUTION: u64 = 1024 * 1024 * 32; // 32M cycles
+/// The cycle budget applied to public execution paths that do not yet carry
+/// a transaction-specific budget. Enforcement of the fee spec's per-block cap
+/// replaces this in the charging transition.
+pub const DEFAULT_PUBLIC_CYCLE_BUDGET: u64 = 1024 * 1024 * 32; // 32M cycles
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Program {
@@ -59,10 +60,11 @@ impl Program {
         caller_program_id: Option<ProgramId>,
         pre_states: &[AccountWithMetadata],
         instruction_data: &InstructionData,
-    ) -> Result<ProgramOutput, LeeError> {
+        cycle_budget: u64,
+    ) -> Result<(ProgramOutput, u64), LeeError> {
         // Write inputs to the program
         let mut env_builder = ExecutorEnv::builder();
-        env_builder.session_limit(Some(MAX_NUM_CYCLES_PUBLIC_EXECUTION));
+        env_builder.session_limit(Some(cycle_budget));
         self.write_inputs(
             caller_program_id,
             pre_states,
@@ -72,10 +74,8 @@ impl Program {
         let env = env_builder.build().unwrap();
 
         // Execute the program (without proving)
-        let executor = default_executor();
-        let session_info = executor
-            .execute(env, self.elf())
-            .map_err(|e| LeeError::ProgramExecutionFailed(e.to_string()))?;
+        let session_info = Self::execute_session(env, self.elf(), cycle_budget)?;
+        let cycles = session_info.cycles();
 
         // Get outputs
         let payload = from_frame(&session_info.journal.bytes).ok_or_else(|| {
@@ -84,7 +84,28 @@ impl Program {
         let program_output = borsh::from_slice(payload)
             .map_err(|e| LeeError::ProgramExecutionFailed(e.to_string()))?;
 
-        Ok(program_output)
+        Ok((program_output, cycles))
+    }
+
+    /// Runs the session, translating the executor's session-limit bail into the
+    /// typed [`LeeError::OutOfGas`]. The only place that error string is
+    /// recognized.
+    ///
+    /// FIXME: This is a brittle string match; the executor should provide a typed error
+    fn execute_session(
+        env: ExecutorEnv<'_>,
+        elf: &[u8],
+        cycle_budget: u64,
+    ) -> Result<risc0_zkvm::SessionInfo, LeeError> {
+        default_executor().execute(env, elf).map_err(|e| {
+            if format!("{e:#}").contains("Session limit exceeded") {
+                LeeError::OutOfGas {
+                    budget: cycle_budget,
+                }
+            } else {
+                LeeError::ProgramExecutionFailed(e.to_string())
+            }
+        })
     }
 
     /// Writes the guest's [`ProgramInput`] as a single length-prefixed borsh frame, the form

--- a/lee/state_machine/src/program/tests.rs
+++ b/lee/state_machine/src/program/tests.rs
@@ -1,10 +1,12 @@
 use lee_core::account::{Account, AccountId, AccountWithMetadata};
 use risc0_zkvm::{ExecutorEnv, default_executor};
 
-use crate::program::Program;
+use crate::{
+    error::LeeError,
+    program::{DEFAULT_PUBLIC_CYCLE_BUDGET, Program},
+};
 
-#[test]
-fn program_execution() {
+fn transfer_fixture() -> (Program, Vec<AccountWithMetadata>, Vec<u8>, u128) {
     let program = crate::test_methods::simple_balance_transfer();
     let balance_to_move: u128 = 11_223_344_556_677;
     let instruction_data = Program::serialize_instruction(balance_to_move).unwrap();
@@ -17,6 +19,17 @@ fn program_execution() {
         AccountId::new([0; 32]),
     );
     let recipient = AccountWithMetadata::new(Account::default(), false, AccountId::new([1; 32]));
+    (
+        program,
+        vec![sender, recipient],
+        instruction_data,
+        balance_to_move,
+    )
+}
+
+#[test]
+fn program_execution() {
+    let (program, pre_states, instruction_data, balance_to_move) = transfer_fixture();
 
     let expected_sender_post = Account {
         balance: 77_665_544_332_211 - balance_to_move,
@@ -26,8 +39,13 @@ fn program_execution() {
         balance: balance_to_move,
         ..Account::default()
     };
-    let program_output = program
-        .execute(None, &[sender, recipient], &instruction_data)
+    let (program_output, _cycles) = program
+        .execute(
+            None,
+            &pre_states,
+            &instruction_data,
+            DEFAULT_PUBLIC_CYCLE_BUDGET,
+        )
         .unwrap();
 
     let [sender_post, recipient_post] = program_output.post_states.try_into().unwrap();
@@ -76,7 +94,9 @@ fn journal_is_the_borsh_frame_of_the_output_and_echoes_instruction_data() {
 #[test]
 fn malformed_journal_frame_is_an_error_not_a_panic() {
     let program = crate::test_methods::malformed_journal();
-    let err = program.execute(None, &[], &Vec::new()).unwrap_err();
+    let err = program
+        .execute(None, &[], &Vec::new(), DEFAULT_PUBLIC_CYCLE_BUDGET)
+        .unwrap_err();
     assert!(
         matches!(
             &err,
@@ -85,4 +105,26 @@ fn malformed_journal_frame_is_an_error_not_a_panic() {
         ),
         "expected malformed-frame ProgramExecutionFailed, got: {err:?}"
     );
+}
+
+#[test]
+fn execute_reports_cycles_within_budget() {
+    let (program, pre_states, instruction_data, _) = transfer_fixture();
+    let (_, cycles) = program
+        .execute(
+            None,
+            &pre_states,
+            &instruction_data,
+            DEFAULT_PUBLIC_CYCLE_BUDGET,
+        )
+        .expect("executes");
+    assert!(cycles > 0);
+    assert!(cycles <= DEFAULT_PUBLIC_CYCLE_BUDGET);
+}
+
+#[test]
+fn tiny_budget_is_out_of_gas() {
+    let (program, pre_states, instruction_data, _) = transfer_fixture();
+    let result = program.execute(None, &pre_states, &instruction_data, 1_024);
+    assert!(matches!(result, Err(LeeError::OutOfGas { budget: 1_024 })));
 }

--- a/lee/state_machine/src/program/tests.rs
+++ b/lee/state_machine/src/program/tests.rs
@@ -119,6 +119,8 @@ fn execute_reports_cycles_within_budget() {
         )
         .expect("executes");
     assert!(cycles > 0);
+    // Holds because this transfer costs far less than the budget; not a general
+    // invariant — a session can overshoot its limit by up to one instruction.
     assert!(cycles <= DEFAULT_PUBLIC_CYCLE_BUDGET);
 }
 

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -67,7 +67,7 @@ impl ExecutionOutcome {
 }
 
 impl ValidatedStateDiff {
-    /// [`Self::from_public_transaction_with_budget`] at the default budget,
+    /// [`Self::from_public_transaction_with_cycle_budget`] at the default budget,
     /// discarding the metered outcome.
     pub fn from_public_transaction(
         tx: &PublicTransaction,
@@ -75,7 +75,7 @@ impl ValidatedStateDiff {
         block_id: BlockId,
         timestamp: Timestamp,
     ) -> Result<Self, LeeError> {
-        Self::from_public_transaction_with_budget(
+        Self::from_public_transaction_with_cycle_budget(
             tx,
             state,
             block_id,
@@ -88,7 +88,7 @@ impl ValidatedStateDiff {
     /// Validates and executes `tx` under `cycle_budget`, shared by every call
     /// in the chain: each nested session is limited to the remaining budget, so
     /// the chain cannot exceed the budget in aggregate.
-    pub fn from_public_transaction_with_budget(
+    pub fn from_public_transaction_with_cycle_budget(
         tx: &PublicTransaction,
         state: &V03State,
         block_id: BlockId,

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -54,13 +54,47 @@ impl ValidatedStateDiff {
     }
 }
 
+/// The metered result of a public execution: the cycle count accumulated
+/// across every call in the chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionOutcome {
+    pub cycles: u64,
+}
+
+impl ExecutionOutcome {
+    /// The outcome of transaction kinds that meter nothing.
+    pub const FREE: Self = Self { cycles: 0 };
+}
+
 impl ValidatedStateDiff {
+    /// [`Self::from_public_transaction_with_budget`] at the default budget,
+    /// discarding the metered outcome.
     pub fn from_public_transaction(
         tx: &PublicTransaction,
         state: &V03State,
         block_id: BlockId,
         timestamp: Timestamp,
     ) -> Result<Self, LeeError> {
+        Self::from_public_transaction_with_budget(
+            tx,
+            state,
+            block_id,
+            timestamp,
+            crate::program::DEFAULT_PUBLIC_CYCLE_BUDGET,
+        )
+        .map(|(diff, _)| diff)
+    }
+
+    /// Validates and executes `tx` under `cycle_budget`, shared by every call
+    /// in the chain: each nested session is limited to the remaining budget, so
+    /// the chain cannot exceed the budget in aggregate.
+    pub fn from_public_transaction_with_budget(
+        tx: &PublicTransaction,
+        state: &V03State,
+        block_id: BlockId,
+        timestamp: Timestamp,
+        cycle_budget: u64,
+    ) -> Result<(Self, ExecutionOutcome), LeeError> {
         let signer_account_ids = authenticate_public_transaction_signers(tx, state)?;
         let message = tx.message();
 
@@ -105,6 +139,7 @@ impl ValidatedStateDiff {
         let mut chained_calls =
             VecDeque::<(ChainedCall, CallerData)>::from_iter([(initial_call, initial_caller_data)]);
         let mut chain_calls_counter = 0;
+        let mut cycles_used: u64 = 0;
 
         while let Some((chained_call, caller_data)) = chained_calls.pop_front() {
             ensure!(
@@ -124,11 +159,15 @@ impl ValidatedStateDiff {
                 "Program {:?} pre_states: {:?}, instruction_data: {:?}",
                 chained_call.program_id, chained_call.pre_states, chained_call.instruction_data
             );
-            let mut program_output = program.execute(
+            let (mut program_output, call_cycles) = program.execute(
                 caller_data.program_id,
                 &chained_call.pre_states,
                 &chained_call.instruction_data,
+                cycle_budget.saturating_sub(cycles_used),
             )?;
+            cycles_used = cycles_used
+                .checked_add(call_cycles)
+                .expect("cycle sums fit u64: each call is bounded by the budget");
             debug!(
                 "Program {:?} output: {:?}",
                 chained_call.program_id, program_output
@@ -319,13 +358,18 @@ impl ValidatedStateDiff {
             );
         }
 
-        Ok(Self(StateDiff {
-            signer_account_ids,
-            public_diff: state_diff,
-            new_commitments: vec![],
-            new_nullifiers: vec![],
-            program: None,
-        }))
+        Ok((
+            Self(StateDiff {
+                signer_account_ids,
+                public_diff: state_diff,
+                new_commitments: vec![],
+                new_nullifiers: vec![],
+                program: None,
+            }),
+            ExecutionOutcome {
+                cycles: cycles_used,
+            },
+        ))
     }
 
     pub fn from_privacy_preserving_transaction(

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -6,7 +6,7 @@ use std::{
 
 use lee_core::{
     BlockId, Commitment, Nullifier, PrivacyPreservingCircuitOutput, PublicAction, Timestamp,
-    account::{Account, AccountId, AccountWithMetadata},
+    account::{Account, AccountId, AccountWithMetadata, Cycles},
     program::{
         CallerData, ChainedCall, Claim, DEFAULT_PROGRAM_OWNER, compute_public_authorized_pdas,
         validate_execution,
@@ -58,7 +58,7 @@ impl ValidatedStateDiff {
 /// across every call in the chain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExecutionOutcome {
-    pub cycles: u64,
+    pub cycles: Cycles,
 }
 
 impl ExecutionOutcome {
@@ -93,7 +93,7 @@ impl ValidatedStateDiff {
         state: &V03State,
         block_id: BlockId,
         timestamp: Timestamp,
-        cycle_budget: u64,
+        cycle_budget: Cycles,
     ) -> Result<(Self, ExecutionOutcome), LeeError> {
         let signer_account_ids = authenticate_public_transaction_signers(tx, state)?;
         let message = tx.message();
@@ -139,7 +139,7 @@ impl ValidatedStateDiff {
         let mut chained_calls =
             VecDeque::<(ChainedCall, CallerData)>::from_iter([(initial_call, initial_caller_data)]);
         let mut chain_calls_counter = 0;
-        let mut cycles_used: u64 = 0;
+        let mut cycles_used: Cycles = 0;
 
         while let Some((chained_call, caller_data)) = chained_calls.pop_front() {
             ensure!(

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -167,7 +167,7 @@ impl ValidatedStateDiff {
             )?;
             cycles_used = cycles_used
                 .checked_add(call_cycles)
-                .expect("cycle sums fit u64: each call is bounded by the budget");
+                .expect("cycle sums fit u64: overflow would need ~2^64 executed cycles");
             debug!(
                 "Program {:?} output: {:?}",
                 chained_call.program_id, program_output

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -165,9 +165,9 @@ impl ValidatedStateDiff {
                 &chained_call.instruction_data,
                 cycle_budget.saturating_sub(cycles_used),
             )?;
-            cycles_used = cycles_used
-                .checked_add(call_cycles)
-                .expect("cycle sums fit u64: overflow would need ~2^64 executed cycles");
+            // saturate here is ok, because this can never be U64::MAX anyways
+            // because the program execution is bounded by the budget
+            cycles_used = cycles_used.saturating_add(call_cycles);
             debug!(
                 "Program {:?} output: {:?}",
                 chained_call.program_id, program_output

--- a/lee/state_machine/src/validated_state_diff/tests.rs
+++ b/lee/state_machine/src/validated_state_diff/tests.rs
@@ -627,9 +627,11 @@ fn chained_calls_share_one_budget() {
     .1
     .cycles;
 
-    // Reported cycles are po2-padded per segment while the session limit gates
-    // actual executed cycles, so a boundary budget (`full_cycles - 1`) can
-    // still pass. A quarter of the chain's total is decisively insufficient.
+    // `cycles()` and the session limit gate the same unpadded user-cycle
+    // counter, but the limit is only checked before each instruction and one
+    // instruction (an ecall) can add up to MAX_INSN_CYCLES (~25k) at once, so a
+    // boundary budget (`full_cycles - 1`) can still complete. A quarter of the
+    // chain's total is decisively insufficient.
     let starved_budget = full_cycles >> 2;
     let starved =
         ValidatedStateDiff::from_public_transaction_with_budget(&tx, &state, 1, 0, starved_budget);

--- a/lee/state_machine/src/validated_state_diff/tests.rs
+++ b/lee/state_machine/src/validated_state_diff/tests.rs
@@ -538,3 +538,105 @@ fn privacy_garbage_proof_is_rejected() {
         Ok(_) => panic!("garbage proof was accepted instead of rejected"),
     }
 }
+
+fn metering_transfer_fixture() -> (V03State, crate::PublicTransaction) {
+    let from_key = PrivateKey::try_new([1_u8; 32]).unwrap();
+    let from = AccountId::from(&PublicKey::new_from_private_key(&from_key));
+    let to_key = PrivateKey::try_new([2_u8; 32]).unwrap();
+    let to = AccountId::from(&PublicKey::new_from_private_key(&to_key));
+
+    let state = V03State::new()
+        .with_public_accounts(public_state_from_balances(&[(from, 100)]))
+        .with_programs(std::iter::once(
+            crate::test_methods::simple_balance_transfer(),
+        ));
+    let program_id = crate::test_methods::simple_balance_transfer().id();
+    let message =
+        Message::try_new(program_id, vec![from, to], vec![Nonce(0), Nonce(0)], 5_u128).unwrap();
+    let witness_set = WitnessSet::for_message(&message, &[&from_key, &to_key]);
+    (state, crate::PublicTransaction::new(message, witness_set))
+}
+
+#[test]
+fn budgeted_execution_reports_cycles_and_matching_diff() {
+    // The same tx through both entry points: identical diff, nonzero cycles.
+    let (state, tx) = metering_transfer_fixture();
+    let (diff, outcome) = ValidatedStateDiff::from_public_transaction_with_budget(
+        &tx,
+        &state,
+        1,
+        0,
+        crate::program::DEFAULT_PUBLIC_CYCLE_BUDGET,
+    )
+    .expect("executes");
+    let unbudgeted =
+        ValidatedStateDiff::from_public_transaction(&tx, &state, 1, 0).expect("executes");
+    assert_eq!(diff.public_diff(), unbudgeted.public_diff());
+    assert!(outcome.cycles > 0);
+    assert!(outcome.cycles <= crate::program::DEFAULT_PUBLIC_CYCLE_BUDGET);
+}
+
+#[test]
+fn exhausted_budget_surfaces_out_of_gas() {
+    let (state, tx) = metering_transfer_fixture();
+    let result = ValidatedStateDiff::from_public_transaction_with_budget(&tx, &state, 1, 0, 1_024);
+    assert!(matches!(result, Err(LeeError::OutOfGas { budget: 1_024 })));
+}
+
+#[test]
+fn chained_calls_share_one_budget() {
+    // A chain-calling tx must exhaust when the budget covers less than the
+    // whole chain, even though each individual call would fit.
+    let chain_caller = crate::test_methods::chain_caller();
+    let from_key = PrivateKey::try_new([1_u8; 32]).unwrap();
+    let from = AccountId::from(&PublicKey::new_from_private_key(&from_key));
+    let to = AccountId::new([2_u8; 32]);
+    let state = V03State::new()
+        .with_public_accounts(public_state_from_balances(&[(from, 1_000), (to, 0)]))
+        .with_test_programs();
+    let instruction: (
+        u128,
+        lee_core::program::ProgramId,
+        u32,
+        Option<lee_core::program::PdaSeed>,
+    ) = (
+        37,
+        crate::test_methods::simple_balance_transfer().id(),
+        2,
+        None,
+    );
+    // The chain_caller program permutes the account order in the chain call.
+    let message = Message::try_new(
+        chain_caller.id(),
+        vec![to, from],
+        vec![Nonce(0)],
+        instruction,
+    )
+    .unwrap();
+    let witness_set = WitnessSet::for_message(&message, &[&from_key]);
+    let tx = crate::PublicTransaction::new(message, witness_set);
+
+    let full_cycles = ValidatedStateDiff::from_public_transaction_with_budget(
+        &tx,
+        &state,
+        1,
+        0,
+        crate::program::DEFAULT_PUBLIC_CYCLE_BUDGET,
+    )
+    .expect("executes under the default budget")
+    .1
+    .cycles;
+
+    // Reported cycles are po2-padded per segment while the session limit gates
+    // actual executed cycles, so a boundary budget (`full_cycles - 1`) can
+    // still pass. A quarter of the chain's total is decisively insufficient.
+    let starved_budget = full_cycles >> 2;
+    let starved =
+        ValidatedStateDiff::from_public_transaction_with_budget(&tx, &state, 1, 0, starved_budget);
+    assert!(matches!(starved, Err(LeeError::OutOfGas { .. })));
+}
+
+#[test]
+fn free_outcome_is_zero_cycles() {
+    assert_eq!(crate::ExecutionOutcome::FREE.cycles, 0);
+}

--- a/lee/state_machine/src/validated_state_diff/tests.rs
+++ b/lee/state_machine/src/validated_state_diff/tests.rs
@@ -561,7 +561,7 @@ fn metering_transfer_fixture() -> (V03State, crate::PublicTransaction) {
 fn budgeted_execution_reports_cycles_and_matching_diff() {
     // The same tx through both entry points: identical diff, nonzero cycles.
     let (state, tx) = metering_transfer_fixture();
-    let (diff, outcome) = ValidatedStateDiff::from_public_transaction_with_budget(
+    let (diff, outcome) = ValidatedStateDiff::from_public_transaction_with_cycle_budget(
         &tx,
         &state,
         1,
@@ -579,7 +579,8 @@ fn budgeted_execution_reports_cycles_and_matching_diff() {
 #[test]
 fn exhausted_budget_surfaces_out_of_gas() {
     let (state, tx) = metering_transfer_fixture();
-    let result = ValidatedStateDiff::from_public_transaction_with_budget(&tx, &state, 1, 0, 1_024);
+    let result =
+        ValidatedStateDiff::from_public_transaction_with_cycle_budget(&tx, &state, 1, 0, 1_024);
     assert!(matches!(result, Err(LeeError::OutOfGas { budget: 1_024 })));
 }
 
@@ -616,7 +617,7 @@ fn chained_calls_share_one_budget() {
     let witness_set = WitnessSet::for_message(&message, &[&from_key]);
     let tx = crate::PublicTransaction::new(message, witness_set);
 
-    let full_cycles = ValidatedStateDiff::from_public_transaction_with_budget(
+    let full_cycles = ValidatedStateDiff::from_public_transaction_with_cycle_budget(
         &tx,
         &state,
         1,
@@ -633,8 +634,13 @@ fn chained_calls_share_one_budget() {
     // boundary budget (`full_cycles - 1`) can still complete. A quarter of the
     // chain's total is decisively insufficient.
     let starved_budget = full_cycles >> 2;
-    let starved =
-        ValidatedStateDiff::from_public_transaction_with_budget(&tx, &state, 1, 0, starved_budget);
+    let starved = ValidatedStateDiff::from_public_transaction_with_cycle_budget(
+        &tx,
+        &state,
+        1,
+        0,
+        starved_budget,
+    );
     assert!(matches!(starved, Err(LeeError::OutOfGas { .. })));
 }
 


### PR DESCRIPTION
## 🎯 Purpose

Fourth PR of the fees train (#746 → #747 → #750 → **#752** → #753 → #754 → #758 → #762).

To charge for public execution we first have to be able to *measure* it. This PR makes public execution metered: every risc0 executor session now reports how many cycles it consumed and runs under an explicit cycle budget, with budget exhaustion surfacing as a typed `LeeError::OutOfGas` instead of an opaque execution failure.

This PR only adds the instrument — **zero behavior change, zero ripple**. All existing entry points keep their signatures (as thin wrappers over the budgeted forms), the default budget equals the previous hardcoded 32M-cycle session limit, and no callers outside `lee/state_machine` are touched. Actually deriving budgets from `gas_limit` and charging for cycles lands later in the train (#753/#754).

## ⚙️ Approach

- Change `Program::execute` to take a `cycle_budget: u64` and return `(ProgramOutput, u64)`, where the cycle count comes from risc0's `SessionInfo::cycles()`. The budget is enforced by passing it as the executor's `session_limit` (`lee/state_machine/src/program/mod.rs`).
- Add `Program::execute_session` as the **single recognition point** that translates the executor's session-limit bail into `LeeError::OutOfGas { budget }`. This is a string match on `"Session limit exceeded"` — admittedly brittle, and marked with a `FIXME` in the code; risc0 doesn't expose a typed error for this today, and confining the match to one function keeps the blast radius minimal.
- Promote the old `MAX_NUM_CYCLES_PUBLIC_EXECUTION` constant to `pub const DEFAULT_PUBLIC_CYCLE_BUDGET` (same 32M value), used by every path that doesn't yet carry a transaction-specific budget — preserving existing behavior exactly.
- Add `ValidatedStateDiff::from_public_transaction_with_budget` returning `(Self, ExecutionOutcome)`. The budget is **shared across the whole call chain**: each nested/chained program session gets `cycle_budget.saturating_sub(cycles_used)` as its limit, so a chain cannot exceed the top-level budget in aggregate (`lee/state_machine/src/validated_state_diff/mod.rs`). The existing `from_public_transaction` becomes a wrapper that applies the default budget and discards the outcome.
- Add `ExecutionOutcome { cycles }` with an `ExecutionOutcome::FREE` constant (0 cycles) for transaction kinds that meter nothing, re-exported from the crate root.
- Add `LeeError::OutOfGas { budget }` (`lee/state_machine/src/error.rs`).
- No guest binary changes — everything here is host-side, so the committed Risc0 `artifacts/` are untouched.

**Key finding (documented in code and tests):** risc0's `SessionInfo::cycles()` reports **po2-padded** per-segment totals, while the session limit gates *actual* executed cycles. A boundary budget (reported cycles − 1) therefore does *not* reliably trip the limit — enforcement granularity is coarser than the reported number. The tests account for this by using decisively insufficient budgets (e.g. a quarter of the measured chain total, not `full_cycles - 1`). The consequence for the charging PR (deferred there): the charged amount must be clamped to `cycles.min(gas_limit)`, and a metered overshoot past the budget must never be treated as a consensus fault.

- [x] Change `Program::execute` to accept a cycle budget and return the metered cycle count
- [x] Add `execute_session` as the single `OutOfGas` recognition point (with `FIXME` on the string match)
- [x] Add `ValidatedStateDiff::from_public_transaction_with_budget` with chain-shared budget accounting and `ExecutionOutcome`
- [x] Add `DEFAULT_PUBLIC_CYCLE_BUDGET` (= previous hardcoded limit) and keep old signatures as wrappers — no behavior change

## 🧪 How to Test

```sh
RISC0_DEV_MODE=1 cargo nextest run -p lee --all-features
```

Covers the new tests:
- `program::tests`: cycles are reported and within budget; a tiny budget yields `OutOfGas { budget }`.
- `validated_state_diff::tests`: the budgeted entry point produces an identical diff to the unbudgeted one with a nonzero cycle outcome; an exhausted budget surfaces `OutOfGas`; a chain-calling transaction that fits per-call still exhausts a starved shared budget (`chained_calls_share_one_budget`, which also documents the po2-padding caveat); `ExecutionOutcome::FREE` is zero.

(`--all-features` matters generally in this workspace — `sequencer_core` tests are silently skipped without it, and CI runs with it.)

Then the CI mirror:

```sh
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo +nightly fmt --check
taplo fmt --check
cargo machete
cargo deny check
```

## 🔗 Dependencies

- #750 (fee wire format) — this branch is stacked on `erhant/fees/fee-wire-format`.

## 🔜 Future Work

Deferred to #753/#754 by design:

- The settlement-shaped `(outcome, Result)` execution form and `MalformedProgramOutput` handling.
- Deriving cycle budgets from the transaction's `gas_limit`, and the `cycles.min(gas_limit)` clamp required by the po2-padding finding above.
- Migrating consumers (sequencer/executor paths) onto the budgeted entry points and actually charging fees.

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments