### PR TITLE
feat(fees): admission screen, getFeeState RPC, and mempool cap budgeting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11009,6 +11009,7 @@ dependencies = [
  "programs",
  "rand 0.8.6",
  "sequencer_core_metrics",
+ "sequencer_service_protocol",
  "sequencer_stake_core",
  "sequencer_storage_actor",
  "serde",
@@ -11055,11 +11056,13 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "sequencer_core",
+ "sequencer_service_protocol",
  "sequencer_stake_core",
  "sequencer_storage_actor",
  "system_accounts",
  "tempfile",
  "test_programs",
+ "testnet_initial_state",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -11129,7 +11132,9 @@ dependencies = [
  "lee",
  "lee_core",
  "serde",
+ "serde_json",
  "serde_with",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/lee/state_machine/src/fees.rs
+++ b/lee/state_machine/src/fees.rs
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    fn tampered_fee_fields_invalidate_every_signature() {
+    fn tampered_fee_declaration_invalidate_every_signature() {
         // The fee fields are inside the signed hash: raising gas_limit after
         // signing must break the payer's signature.
         let (signer_key, _) = keys();

--- a/lez/chain_state/src/apply.rs
+++ b/lez/chain_state/src/apply.rs
@@ -163,15 +163,7 @@ pub fn apply_block_to_state(block: &Block, state: &mut V03State) -> Result<(), B
     // The fee tx is byte-compared only after the user transactions have been
     // settled: its summary is derived from their execution.
 
-    // A malformed fee-state account is consensus-critical corruption (only the
-    // fee guest may write it), so the panic inside `from_bytes` is the
-    // halt-the-node behavior the spec prescribes for consensus faults.
-    let opening = FeeState::from_bytes(
-        &state
-            .get_account_by_id(system_accounts::fee_state_account_id())
-            .data
-            .into_inner(),
-    );
+    let opening = opening_fee_state(state);
     let mut summary = BlockFeeSummary::default();
 
     let is_genesis = block.header.block_id == GENESIS_BLOCK_ID;
@@ -233,6 +225,21 @@ pub fn apply_block_to_state(block: &Block, state: &mut V03State) -> Result<(), B
     Ok(())
 }
 
+/// Reads the fee state a block opening on `state` prices against.
+///
+/// A malformed fee-state account is consensus-critical corruption (only the
+/// fee guest may write it), so the panic inside `from_bytes` is the
+/// halt-the-node behavior the spec prescribes for consensus faults.
+#[must_use]
+pub fn opening_fee_state(state: &V03State) -> FeeState {
+    FeeState::from_bytes(
+        &state
+            .get_account_by_id(system_accounts::fee_state_account_id())
+            .data
+            .into_inner(),
+    )
+}
+
 /// Derives the block fee summary the given user transactions settle to.
 ///
 /// Runs the settlement on a scratch clone of `state`. What block builders
@@ -244,12 +251,7 @@ pub fn derive_block_summary(
     timestamp: Timestamp,
 ) -> Result<BlockFeeSummary, BlockIngestError> {
     let mut scratch = state.clone();
-    let opening = FeeState::from_bytes(
-        &scratch
-            .get_account_by_id(system_accounts::fee_state_account_id())
-            .data
-            .into_inner(),
-    );
+    let opening = opening_fee_state(state);
     let mut summary = BlockFeeSummary::default();
     for (tx_index, transaction) in transactions.iter().enumerate() {
         settle_transaction(
@@ -761,7 +763,7 @@ mod tests {
             fee_core::Instruction::Refund {
                 amount: inbox_revenue,
             },
-            common::test_utils::test_fee_fields(attacker),
+            common::test_utils::test_fee_declaration(attacker),
         )
         .expect("drain message builds");
         let witness = lee::public_transaction::WitnessSet::for_message(&message, &[&attacker_key]);

--- a/lez/chain_state/src/apply.rs
+++ b/lez/chain_state/src/apply.rs
@@ -251,7 +251,7 @@ pub fn derive_block_summary(
     timestamp: Timestamp,
 ) -> Result<BlockFeeSummary, BlockIngestError> {
     let mut scratch = state.clone();
-    let opening = opening_fee_state(state);
+    let opening = opening_fee_state(&scratch);
     let mut summary = BlockFeeSummary::default();
     for (tx_index, transaction) in transactions.iter().enumerate() {
         settle_transaction(

--- a/lez/common/src/test_utils.rs
+++ b/lez/common/src/test_utils.rs
@@ -106,7 +106,7 @@ pub fn produce_dummy_empty_transaction() -> LeeTransaction {
 /// Generous fee fields for test transactions: the sender pays, with a default
 /// gas limit and an effectively unbounded fee cap.
 #[must_use]
-pub const fn test_fee_fields(payer: AccountId) -> lee::FeeDeclaration {
+pub const fn test_fee_declaration(payer: AccountId) -> lee::FeeDeclaration {
     lee::FeeDeclaration::new(payer, 2_000_000, 0, u128::MAX >> 1)
 }
 
@@ -118,6 +118,25 @@ pub fn create_transaction_native_token_transfer(
     balance_to_move: u128,
     signing_key: &lee::PrivateKey,
 ) -> LeeTransaction {
+    create_transaction_native_token_transfer_with_fees(
+        from,
+        nonce,
+        to,
+        balance_to_move,
+        signing_key,
+        test_fee_declaration(from),
+    )
+}
+
+#[must_use]
+pub fn create_transaction_native_token_transfer_with_fees(
+    from: AccountId,
+    nonce: u128,
+    to: AccountId,
+    balance_to_move: u128,
+    signing_key: &lee::PrivateKey,
+    fee_declaration: lee::FeeDeclaration,
+) -> LeeTransaction {
     let account_ids = vec![from, to];
     let nonces = vec![nonce.into()];
     let program_id = programs::authenticated_transfer().id();
@@ -128,7 +147,7 @@ pub fn create_transaction_native_token_transfer(
         authenticated_transfer_core::Instruction::Transfer {
             amount: balance_to_move,
         },
-        test_fee_fields(from),
+        fee_declaration,
     )
     .unwrap();
     let witness_set = lee::public_transaction::WitnessSet::for_message(&message, &[signing_key]);

--- a/lez/sequencer/actors/executor/Cargo.toml
+++ b/lez/sequencer/actors/executor/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 sequencer_core.workspace = true
+sequencer_service_protocol.workspace = true
 common.workspace = true
 lee_core.workspace = true
 mempool.workspace = true
@@ -31,6 +32,7 @@ sequencer_storage_actor = { workspace = true, features = ["mock"] }
 system_accounts.workspace = true
 sequencer_stake_core.workspace = true
 test_programs.workspace = true
+testnet_initial_state.workspace = true
 
 env_logger.workspace = true
 mockall.workspace = true

--- a/lez/sequencer/actors/executor/src/actor.rs
+++ b/lez/sequencer/actors/executor/src/actor.rs
@@ -305,7 +305,10 @@ impl<BP: BlockPublisherTrait + Send + Sync + 'static, S: StorageActorTrait> Mess
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         GetFeeQuoteReply {
-            quote: self.sequencer.with_state(sequencer_core::fees::fee_quote).await,
+            quote: self
+                .sequencer
+                .with_state(sequencer_core::fees::fee_quote)
+                .await,
         }
     }
 }

--- a/lez/sequencer/actors/executor/src/actor.rs
+++ b/lez/sequencer/actors/executor/src/actor.rs
@@ -32,7 +32,8 @@ use crate::{
     protocol::{
         GetAccount, GetAccountBalance, GetAccountNonces, GetAccountReply, GetBlock, GetBlockRange,
         GetChannelId, GetChannelIdReply, GetCrossZoneDeadLetters, GetCrossZoneDeadLettersReply,
-        GetLastBlockId, GetProofsAndRoot, GetTransaction, ProduceBlock, Transaction,
+        GetFeeQuote, GetFeeQuoteReply, GetLastBlockId, GetProofsAndRoot, GetTransaction,
+        ProduceBlock, SubmitOutcome, Transaction,
     },
 };
 
@@ -192,16 +193,28 @@ impl<BP: BlockPublisherTrait + Send + Sync + 'static, S: StorageActorTrait> Mess
 impl<BP: BlockPublisherTrait + Send + Sync + 'static, S: StorageActorTrait> Message<Transaction>
     for ExecutorActor<BP, S>
 {
-    type Reply = Result<()>;
+    type Reply = Result<SubmitOutcome>;
 
     async fn handle(
         &mut self,
         Transaction { transaction }: Transaction,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // Fee admission against the head state, before the mempool sees it.
+        // Advisory (base fees and balances move), but everything it turns
+        // away would have been refused by the block builder anyway.
+        if let Err(rejection) = self
+            .sequencer
+            .with_state(|state| sequencer_core::fees::screen(&transaction, state))
+            .await
+        {
+            return Ok(SubmitOutcome::Rejected(rejection));
+        }
+
         self.mempool_handle
             .try_push((TransactionOrigin::User, transaction))
-            .map_err(|_err| Error::MempoolIsFull)
+            .map_err(|_err| Error::MempoolIsFull)?;
+        Ok(SubmitOutcome::Admitted)
     }
 }
 
@@ -278,6 +291,22 @@ impl<BP: BlockPublisherTrait + Send + Sync + 'static, S: StorageActorTrait>
         self.sequencer
             .with_state(|state| state.get_account_by_id(account_id).balance)
             .await
+    }
+}
+
+impl<BP: BlockPublisherTrait + Send + Sync + 'static, S: StorageActorTrait> Message<GetFeeQuote>
+    for ExecutorActor<BP, S>
+{
+    type Reply = GetFeeQuoteReply;
+
+    async fn handle(
+        &mut self,
+        GetFeeQuote: GetFeeQuote,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        GetFeeQuoteReply {
+            quote: self.sequencer.with_state(sequencer_core::fees::fee_quote).await,
+        }
     }
 }
 

--- a/lez/sequencer/actors/executor/src/protocol.rs
+++ b/lez/sequencer/actors/executor/src/protocol.rs
@@ -6,6 +6,7 @@ use lee_core::{
     BlockId, Commitment,
     account::{Account, AccountId},
 };
+use sequencer_service_protocol::AdmissionRejection;
 
 /// The widest range a [`GetBlockRange`] may span.
 pub const MAX_BLOCK_RANGE_LEN: usize = 1024;
@@ -15,6 +16,25 @@ pub struct ProduceBlock;
 
 pub struct Transaction {
     pub transaction: LeeTransaction,
+}
+
+/// What fee admission decided about a submitted transaction.
+///
+/// A rejection is a reply, not an actor failure: the transaction was handled,
+/// and the verdict is the answer the RPC layer renders back to the client.
+#[derive(Debug, Reply)]
+pub enum SubmitOutcome {
+    /// Screened and pushed to the mempool.
+    Admitted,
+    /// Refused at the fee-admission door; never entered the mempool.
+    Rejected(AdmissionRejection),
+}
+
+pub struct GetFeeQuote;
+
+#[derive(Reply)]
+pub struct GetFeeQuoteReply {
+    pub quote: sequencer_service_protocol::FeeStateQuote,
 }
 
 pub struct GetBlock {

--- a/lez/sequencer/actors/executor/src/tests.rs
+++ b/lez/sequencer/actors/executor/src/tests.rs
@@ -51,22 +51,28 @@ fn sequencer_config() -> (SequencerConfig, TempDir) {
 }
 
 fn test_transaction() -> LeeTransaction {
-    let key1 = PrivateKey::new_os_random();
     let key2 = PrivateKey::new_os_random();
-    let acc1 = AccountId::from(&PublicKey::new_from_private_key(&key1));
     let acc2 = AccountId::from(&PublicKey::new_from_private_key(&key2));
+
+    // Fees are self-pay: the payer must be a funded initial-state account that
+    // signs the transaction in the ordinary witness set, so it leads the
+    // account list and signs alongside the other party.
+    let accounts = testnet_initial_state::initial_pub_accounts_private_keys();
+    let payer = accounts[0].account_id;
+    let payer_key = accounts[0].pub_sign_key.clone();
 
     let nonces = vec![0_u128.into(), 0_u128.into()];
     let instruction = 1337;
-    let message = Message::try_new(
+    let message = Message::try_new_with_fees(
         test_programs::simple_balance_transfer().id(),
-        vec![acc1, acc2],
+        vec![payer, acc2],
         nonces,
         instruction,
+        common::test_utils::test_fee_declaration(payer),
     )
     .unwrap();
 
-    let witness_set = WitnessSet::for_message(&message, &[&key1, &key2]);
+    let witness_set = WitnessSet::for_message(&message, &[&payer_key, &key2]);
     PublicTransaction::new(message, witness_set).into()
 }
 
@@ -182,9 +188,13 @@ async fn handle_transaction_fails_on_full_mempool() -> Result<()> {
     // Fill mempool
     for _ in 0..mempool_max_size {
         let tx = test_transaction();
-        executor
+        let outcome = executor
             .ask(protocol::Transaction { transaction: tx })
             .await?;
+        assert!(
+            matches!(outcome, protocol::SubmitOutcome::Admitted),
+            "a funded, authorized submission must pass admission, got: {outcome:?}",
+        );
     }
 
     // Now the mempool is full, the next transaction should fail
@@ -268,6 +278,59 @@ async fn get_block_range_keeps_executor_responsive() -> Result<()> {
     storage_ref
         .tell(sequencer_storage_actor::mock::Checkpoint)
         .await?;
+
+    Ok(())
+}
+
+#[test]
+async fn handle_transaction_rejects_a_fee_invalid_submission() -> Result<()> {
+    let _res = env_logger::try_init();
+
+    let (config, _home) = sequencer_config();
+    let mock_storage = prepare_mock_storage_with_empty_genesis();
+    let storage_ref = MockStorageActor::spawn(mock_storage);
+    let executor = ExecutorActor::spawn(
+        ExecutorActor::<MockBlockPublisher, _>::new(config, storage_ref.clone()).await,
+    );
+    storage_ref
+        .tell(sequencer_storage_actor::mock::Checkpoint)
+        .await?;
+
+    // A charged transaction whose max_fee is 0 can never cover its reserve
+    // (which prices at least the serialized bytes), so admission's static check
+    // rejects it before it reaches the mempool. The fee is declared (so it
+    // classifies as charged, not `MissingFeeDeclaration`) but set to 0.
+    let key2 = PrivateKey::new_os_random();
+    let acc2 = AccountId::from(&PublicKey::new_from_private_key(&key2));
+    let accounts = testnet_initial_state::initial_pub_accounts_private_keys();
+    let payer = accounts[0].account_id;
+    let payer_key = accounts[0].pub_sign_key.clone();
+    let message = Message::try_new_with_fees(
+        test_programs::simple_balance_transfer().id(),
+        vec![payer, acc2],
+        vec![0_u128.into(), 0_u128.into()],
+        1337,
+        lee::FeeDeclaration::new(payer, 2_000_000, 0, 0),
+    )
+    .unwrap();
+    let witness_set = WitnessSet::for_message(&message, &[&payer_key, &key2]);
+    let tx: LeeTransaction = PublicTransaction::new(message, witness_set).into();
+
+    let outcome = executor
+        .ask(protocol::Transaction { transaction: tx })
+        .await?;
+    assert!(
+        matches!(
+            outcome,
+            protocol::SubmitOutcome::Rejected(
+                sequencer_service_protocol::AdmissionRejection::MaxFeeBelowReserve {
+                    max_fee: 0,
+                    ..
+                }
+            )
+        ),
+        "expected the max-fee rejection, got: {outcome:?}",
+    );
 
     Ok(())
 }

--- a/lez/sequencer/actors/rpc_server/src/actor/service.rs
+++ b/lez/sequencer/actors/rpc_server/src/actor/service.rs
@@ -10,8 +10,9 @@ use kameo::actor::ActorRef;
 use log::{error, warn};
 use sequencer_core::{block_publisher::BlockPublisherTrait, gossip::GossipTxPublisher};
 use sequencer_service_protocol::{
-    Account, AccountId, Block, BlockId, ChannelId, Commitment, CommitmentSetDigest,
-    CrossZoneDeadLetter, CrossZoneDeadLetterReport, HashType, MembershipProof, Nonce, ProgramId,
+    Account, AccountId, AdmissionRejection, Block, BlockId, ChannelId, Commitment,
+    CommitmentSetDigest, CrossZoneDeadLetter, CrossZoneDeadLetterReport, FeeStateQuote, HashType,
+    MembershipProof, Nonce, ProgramId,
 };
 
 pub struct Service<BP: BlockPublisherTrait + Send + Sync + 'static> {
@@ -102,20 +103,39 @@ impl<BP: BlockPublisherTrait + Send + Sync + 'static> sequencer_service_rpc::Rpc
             error!("Transaction failed before reaching mempool: {err:#?}");
         })?;
 
-        // Publish to the gossip mesh before the local mempool admission so a
-        // full mempool doesn't delay propagation.
-        if let Some(publisher) = &self.gossip_tx_publisher {
-            publisher.publish(authenticated_tx.clone());
-        }
-
-        self.executor_ref
+        // The executor screens the transaction against the head state (fee
+        // admission) before pushing it to the mempool; a rejection comes back
+        // as a verdict, not an actor failure.
+        let outcome = self
+            .executor_ref
             .ask(sequencer_executor_actor::protocol::Transaction {
-                transaction: authenticated_tx,
+                transaction: authenticated_tx.clone(),
             })
             .await
             .map_err(internal_error)?;
+        if let sequencer_executor_actor::protocol::SubmitOutcome::Rejected(rejection) = outcome {
+            sequencer_rpc_server_actor_metrics::increment_before_mempool_failed_transactions_total(
+            );
+            warn!("Transaction refused at fee admission: {rejection}");
+            return Err(rejection_error(&rejection));
+        }
+
+        // Published only once admitted, so peers are not fed what the door
+        // refused. (A full local mempool has already errored above, so a
+        // publish cannot be lost to it either.)
+        if let Some(publisher) = &self.gossip_tx_publisher {
+            publisher.publish(authenticated_tx);
+        }
 
         Ok(tx_hash)
+    }
+
+    async fn get_fee_state(&self) -> Result<FeeStateQuote, ErrorObjectOwned> {
+        self.executor_ref
+            .ask(sequencer_executor_actor::protocol::GetFeeQuote)
+            .await
+            .map(|reply| reply.quote)
+            .map_err(internal_error)
     }
 
     async fn check_health(&self) -> Result<(), ErrorObjectOwned> {
@@ -256,4 +276,11 @@ impl<BP: BlockPublisherTrait + Send + Sync + 'static> sequencer_service_rpc::Rpc
 
 fn internal_error(err: impl std::fmt::Display) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(ErrorCode::InternalError.code(), err.to_string(), None::<()>)
+}
+
+/// The JSON-RPC error a fee-admission rejection is returned as: its own code,
+/// the rendered reason, and the structured rejection in `data` for a client
+/// that would rather not parse prose.
+fn rejection_error(rejection: &AdmissionRejection) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(rejection.code(), rejection.to_string(), Some(rejection))
 }

--- a/lez/sequencer/core/Cargo.toml
+++ b/lez/sequencer/core/Cargo.toml
@@ -28,6 +28,7 @@ system_accounts.workspace = true
 cross_zone.workspace = true
 cross_zone_inbox_core.workspace = true
 sequencer_stake_core.workspace = true
+sequencer_service_protocol.workspace = true
 
 logos-blockchain-key-management-system-service.workspace = true
 logos-blockchain-core.workspace = true

--- a/lez/sequencer/core/src/fees.rs
+++ b/lez/sequencer/core/src/fees.rs
@@ -350,7 +350,7 @@ mod tests {
         state.force_insert_account(
             vault_id,
             lee::Account {
-                program_owner: programs::vault().id(),
+                program_owner: programs::vault().id().into(),
                 balance: 500_000_000,
                 ..lee::Account::default()
             },

--- a/lez/sequencer/core/src/fees.rs
+++ b/lez/sequencer/core/src/fees.rs
@@ -1,0 +1,464 @@
+//! Fee admission and pricing for the RPC ingest path.
+//!
+//! Admission is **anti-spam, not consensus**: the block transition
+//! (`chain_state::apply::settle_charged_transaction`) enforces these rules
+//! authoritatively. What this adds is a door — a transaction no block could
+//! ever include is turned away at submission instead of sitting in the
+//! mempool, and the client is told which rule it broke as a typed
+//! [`AdmissionRejection`] instead of watching its transaction silently never
+//! land.
+//!
+//! Two of the checks are advisory by nature: base fees move every block and
+//! balances move every transaction, so the `max_fee >= fee_reserve` and
+//! payer-affordability verdicts are judged against the head state at
+//! submission time and can go stale either way afterwards. The rest are
+//! static properties of the transaction and cannot.
+
+use chain_state::{
+    apply::opening_fee_state,
+    classify::{ClassifyError, FeeClass, classify},
+};
+use common::transaction::LeeTransaction;
+use fee_core::{
+    assess::fee_reserve,
+    market,
+    validity::{FeeError, validate_static_tx},
+};
+use sequencer_service_protocol::{AdmissionRejection, FeeStateQuote};
+
+/// Screens a submitted transaction against the head state.
+///
+/// The checks run in the order `settle_charged_transaction` runs the same
+/// ones, plus the payer-affordability check that only a live state can
+/// answer. Fee-exempt classes pass unscreened: exempt transactions pay
+/// nothing and contribute nothing to the block gas totals under the interim
+/// policy.
+///
+/// # Errors
+///
+/// The first check that fails, with the values that decided it.
+pub fn screen(tx: &LeeTransaction, state: &lee::V03State) -> Result<(), AdmissionRejection> {
+    let class = classify(tx, false, state).map_err(|err| match err {
+        ClassifyError::Unserializable(err) => AdmissionRejection::OtherFeeValidity {
+            reason: format!("unserializable transaction: {err}"),
+        },
+        ClassifyError::MissingFeeDeclaration => AdmissionRejection::MissingFeeDeclaration,
+    })?;
+    let FeeClass::Charged(view) = class else {
+        return Ok(());
+    };
+    let LeeTransaction::Public(public_tx) = tx else {
+        unreachable!("only public transactions classify as charged");
+    };
+    let fee_state = opening_fee_state(state);
+
+    validate_static_tx(&view, &fee_state).map_err(static_rejection)?;
+
+    let payer = view.payer();
+    if !lee::is_fee_authorized(public_tx.message(), public_tx.witness_set()) {
+        return Err(AdmissionRejection::UnauthorizedPayer { payer });
+    }
+
+    let fee_reserve = fee_reserve(&view, &fee_state);
+    let balance = state.get_account_by_id(payer).balance;
+    if balance < fee_reserve {
+        return Err(AdmissionRejection::PayerCannotFund {
+            payer,
+            balance,
+            fee_reserve,
+        });
+    }
+
+    Ok(())
+}
+
+/// One static fee-validity failure, as the rejection carrying its comparands.
+///
+/// The accumulator arms belong to block-level totals admission never sums;
+/// they fall through to the catch-all so the mapping stays total without a
+/// wildcard.
+fn static_rejection(err: FeeError) -> AdmissionRejection {
+    match err {
+        FeeError::DataBytesOutOfRange { data_bytes } => AdmissionRejection::DataBytesOutOfRange {
+            data_bytes,
+            max: market::MAX_GAS_STOR,
+        },
+        FeeError::GasLimitAboveCap { gas_limit } => AdmissionRejection::GasLimitExceedsMax {
+            gas_limit,
+            max: market::MAX_GAS_EXEC,
+        },
+        FeeError::MaxFeeBelowReserve {
+            fee_reserve,
+            max_fee,
+        } => AdmissionRejection::MaxFeeBelowReserve {
+            fee_reserve,
+            max_fee,
+        },
+        FeeError::ExecGasCapExceeded { .. } | FeeError::StorGasCapExceeded { .. } => {
+            AdmissionRejection::OtherFeeValidity {
+                reason: err.to_string(),
+            }
+        }
+    }
+}
+
+/// Prices the next block off the head state's fee market.
+///
+/// The next-block figures are a band rather than a single estimate: the block
+/// being filled is not observable at query time, so the quote steps the
+/// market once at an empty block and once at a block filled to its caps.
+/// Every possible next-block base fee lies between them, which is exactly
+/// what a wallet needs to size `max_fee` for a transaction that may wait.
+/// Both steps go through the same `fee_core` arithmetic the block transition
+/// moves the real fee state with.
+#[must_use]
+pub fn fee_quote(state: &lee::V03State) -> FeeStateQuote {
+    let fee_state = opening_fee_state(state);
+    let step_exec = |gas_used: u64| {
+        market::next_base_fee(
+            fee_state.base_fee_exec,
+            gas_used,
+            market::TARGET_GAS_EXEC,
+            market::D_EXEC,
+            market::BASE_FEE_EXEC_MIN,
+            market::BASE_FEE_EXEC_MAX,
+        )
+    };
+    let step_stor = |gas_used: u64| {
+        market::next_base_fee(
+            fee_state.base_fee_stor,
+            gas_used,
+            market::TARGET_GAS_STOR,
+            market::D_STOR,
+            market::BASE_FEE_STOR_MIN,
+            market::BASE_FEE_STOR_MAX,
+        )
+    };
+
+    FeeStateQuote {
+        height: fee_state.height,
+        base_fee_exec: fee_state.base_fee_exec,
+        base_fee_stor: fee_state.base_fee_stor,
+        next_base_fee_exec_floor: step_exec(0),
+        next_base_fee_exec_ceiling: step_exec(market::MAX_GAS_EXEC),
+        next_base_fee_stor_floor: step_stor(0),
+        next_base_fee_stor_ceiling: step_stor(market::MAX_GAS_STOR),
+        max_gas_exec: market::MAX_GAS_EXEC,
+        max_gas_stor: market::MAX_GAS_STOR,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::test_utils::{
+        create_transaction_native_token_transfer,
+        create_transaction_native_token_transfer_with_fees,
+        create_transaction_native_token_transfer_without_fee,
+    };
+    use fee_core::BlockFeeSummary;
+    use lee::{AccountId, FeeDeclaration, PrivateKey, PublicKey};
+    use testnet_initial_state::{initial_pub_accounts_private_keys, initial_state};
+
+    use super::*;
+
+    /// The gas limit test transactions declare (`test_fee_declaration`).
+    const TEST_GAS_LIMIT: u64 = 2_000_000;
+
+    fn key(seed: u8) -> PrivateKey {
+        PrivateKey::try_new([seed; 32]).expect("valid key")
+    }
+
+    fn account_of(private_key: &PrivateKey) -> AccountId {
+        AccountId::from(&PublicKey::new_from_private_key(private_key))
+    }
+
+    /// A funded account of the initial state, and the key that signs for it.
+    fn funded() -> (AccountId, PrivateKey) {
+        let accounts = initial_pub_accounts_private_keys();
+        (accounts[0].account_id, accounts[0].pub_sign_key.clone())
+    }
+
+    fn recipient() -> AccountId {
+        initial_pub_accounts_private_keys()[1].account_id
+    }
+
+    fn wire_size(tx: &LeeTransaction) -> u64 {
+        u64::try_from(borsh::to_vec(tx).expect("serializes").len()).expect("fits")
+    }
+
+    /// What the block transition says about the same transaction: admission
+    /// must be at least as strict for the checks both run, so nothing it
+    /// admits is unbuildable.
+    fn settle_verdict(tx: &LeeTransaction, state: &lee::V03State) -> Result<(), String> {
+        let mut scratch = state.clone();
+        let opening = opening_fee_state(state);
+        let mut summary = BlockFeeSummary::default();
+        chain_state::apply::settle_transaction(tx, &mut scratch, &opening, 2, 200, 0, &mut summary)
+            .map_err(|err| err.to_string())
+    }
+
+    #[test]
+    fn a_funded_transfer_is_admitted() {
+        let state = initial_state();
+        let (from, sign_key) = funded();
+        let tx = create_transaction_native_token_transfer(from, 0, recipient(), 10, &sign_key);
+
+        screen(&tx, &state).expect("a well-formed, funded transfer is admitted");
+        settle_verdict(&tx, &state).expect("and the block transition agrees");
+    }
+
+    #[test]
+    fn a_transfer_without_a_fee_is_rejected() {
+        let state = initial_state();
+        let (from, sign_key) = funded();
+        // Omitting the fee would be executed for free if admitted; the door
+        // turns it away, and the block transition agrees.
+        let tx = create_transaction_native_token_transfer_without_fee(
+            from,
+            0,
+            recipient(),
+            10,
+            &sign_key,
+        );
+
+        assert_eq!(
+            screen(&tx, &state).expect_err("a fee-less transfer is turned away at the door"),
+            AdmissionRejection::MissingFeeDeclaration,
+        );
+        assert!(settle_verdict(&tx, &state).is_err());
+    }
+
+    #[test]
+    fn a_gas_limit_beyond_the_block_cap_is_rejected() {
+        let state = initial_state();
+        let (from, sign_key) = funded();
+        let tx = create_transaction_native_token_transfer_with_fees(
+            from,
+            0,
+            recipient(),
+            10,
+            &sign_key,
+            FeeDeclaration::new(from, market::MAX_GAS_EXEC + 1, 0, u128::MAX >> 1),
+        );
+
+        let err = screen(&tx, &state).expect_err("no block can execute that much gas");
+        assert_eq!(
+            err,
+            AdmissionRejection::GasLimitExceedsMax {
+                gas_limit: market::MAX_GAS_EXEC + 1,
+                max: market::MAX_GAS_EXEC,
+            },
+        );
+        assert!(settle_verdict(&tx, &state).is_err());
+    }
+
+    #[test]
+    fn a_max_fee_below_the_reserve_is_rejected() {
+        let state = initial_state();
+        let (from, sign_key) = funded();
+        let tx = create_transaction_native_token_transfer_with_fees(
+            from,
+            0,
+            recipient(),
+            10,
+            &sign_key,
+            FeeDeclaration::new(from, TEST_GAS_LIMIT, 7, 1),
+        );
+
+        // At the genesis base fees of 8/8 the reserve prices the declared
+        // gas limit, the serialized bytes, and the tip.
+        let fee_state = opening_fee_state(&state);
+        let expected = u128::from(TEST_GAS_LIMIT) * u128::from(fee_state.base_fee_exec)
+            + u128::from(wire_size(&tx)) * u128::from(fee_state.base_fee_stor)
+            + 7;
+
+        let err = screen(&tx, &state).expect_err("a max_fee of 1 covers nothing");
+        assert_eq!(
+            err,
+            AdmissionRejection::MaxFeeBelowReserve {
+                fee_reserve: expected,
+                max_fee: 1,
+            },
+        );
+        assert!(settle_verdict(&tx, &state).is_err());
+    }
+
+    /// The payer signs the transaction (self-pay) but holds nothing, so the
+    /// reservation the next block would take cannot succeed.
+    #[test]
+    fn a_payer_that_cannot_fund_the_reserve_is_rejected() {
+        let state = initial_state();
+        let broke_key = key(9);
+        let broke = account_of(&broke_key);
+        let tx = create_transaction_native_token_transfer_with_fees(
+            broke,
+            0,
+            recipient(),
+            10,
+            &broke_key,
+            FeeDeclaration::new(broke, TEST_GAS_LIMIT, 0, u128::MAX >> 1),
+        );
+
+        let err = screen(&tx, &state).expect_err("a payer with no balance cannot fund it");
+        assert!(
+            matches!(
+                err,
+                AdmissionRejection::PayerCannotFund {
+                    payer,
+                    balance: 0,
+                    ..
+                } if payer == broke,
+            ),
+            "expected an unfundable payer, got: {err}",
+        );
+        // Affordability is admission-only: the block transition rejects this
+        // one later, at the reserve debit itself.
+        assert!(settle_verdict(&tx, &state).is_err());
+    }
+
+    #[test]
+    fn a_payer_nothing_authorizes_is_rejected() {
+        let state = initial_state();
+        let (from, sign_key) = funded();
+        let stranger = account_of(&key(9));
+        let tx = create_transaction_native_token_transfer_with_fees(
+            from,
+            0,
+            recipient(),
+            10,
+            &sign_key,
+            FeeDeclaration::new(stranger, TEST_GAS_LIMIT, 0, u128::MAX >> 1),
+        );
+
+        let err = screen(&tx, &state).expect_err("nobody authorized the stranger to pay");
+        assert!(
+            matches!(err, AdmissionRejection::UnauthorizedPayer { payer } if payer == stranger),
+            "expected an unauthorized payer, got: {err}",
+        );
+        assert!(settle_verdict(&tx, &state).is_err());
+    }
+
+    /// The bootstrap case: a full vault sweep is fee-exempt, so none of the
+    /// charged checks may run against it — its whole point is that the
+    /// sweeper holds nothing yet.
+    #[test]
+    fn a_full_vault_sweep_by_an_unfunded_account_is_admitted() {
+        let mut state = initial_state();
+        let sweeper_key = key(9);
+        let sweeper = account_of(&sweeper_key);
+        let vault_id = vault_core::compute_vault_account_id(programs::vault().id(), sweeper);
+        state.force_insert_account(
+            vault_id,
+            lee::Account {
+                program_owner: programs::vault().id(),
+                balance: 500_000_000,
+                ..lee::Account::default()
+            },
+        );
+
+        let message = lee::public_transaction::Message::try_new_with_fees(
+            programs::vault().id(),
+            vec![sweeper, vault_id],
+            vec![0_u128.into()],
+            vault_core::Instruction::Claim {
+                amount: 500_000_000,
+            },
+            // A sweep is exempt whatever it declares, and a wallet with
+            // nothing to pay with signs a zero max_fee: neither the reserve
+            // check nor the balance check may see this.
+            FeeDeclaration::new(sweeper, TEST_GAS_LIMIT, 0, 0),
+        )
+        .expect("message builds");
+        let witness_set =
+            lee::public_transaction::WitnessSet::for_message(&message, &[&sweeper_key]);
+        let tx = LeeTransaction::Public(lee::PublicTransaction::new(message, witness_set));
+
+        screen(&tx, &state).expect("a full sweep must be admitted unscreened");
+    }
+
+    /// Private transactions are fee-exempt under the interim policy, so
+    /// admission has nothing to check against one.
+    #[test]
+    fn a_private_transaction_is_admitted_unscreened() {
+        use lee::privacy_preserving_transaction::{
+            Message as PrivateMessage, PrivacyPreservingTransaction,
+            WitnessSet as PrivateWitnessSet, circuit::Proof,
+        };
+
+        let state = initial_state();
+        let tx = LeeTransaction::PrivacyPreserving(PrivacyPreservingTransaction::new(
+            PrivateMessage::default(),
+            PrivateWitnessSet::from_raw_parts(vec![], Proof::from_inner(vec![])),
+        ));
+
+        screen(&tx, &state).expect("private transactions are uncharged and unscreened");
+    }
+
+    /// Deployments are exempt *and* uncapped in the delivered interim policy
+    /// (they contribute nothing to the block gas totals), so even one larger
+    /// than the storage cap passes — a deliberate divergence from the
+    /// reference design, where uncharged transactions were still capped.
+    /// The block size limit at ingest is what bounds it.
+    #[test]
+    fn an_oversized_deployment_is_admitted_unscreened() {
+        let state = initial_state();
+        let bytecode = vec![0_u8; usize::try_from(market::MAX_GAS_STOR).expect("fits") + 1];
+        let tx = LeeTransaction::ProgramDeployment(lee::ProgramDeploymentTransaction::new(
+            lee::program_deployment_transaction::Message::new(bytecode),
+        ));
+
+        screen(&tx, &state).expect("deployments are uncharged and uncapped today");
+    }
+
+    /// SPECS §Overview worked example: at the genesis base fees of 8/8 the
+    /// next block's fees can only stay at the minimum or rise by the
+    /// guaranteed +1 step.
+    #[test]
+    fn the_quote_prices_the_head_fee_state() {
+        let state = initial_state();
+        let quote = fee_quote(&state);
+
+        assert_eq!(quote.height, 0);
+        assert_eq!(quote.base_fee_exec, 8);
+        assert_eq!(quote.base_fee_stor, 8);
+        assert_eq!(quote.next_base_fee_exec_floor, 8);
+        assert_eq!(quote.next_base_fee_exec_ceiling, 9);
+        assert_eq!(quote.next_base_fee_stor_floor, 8);
+        assert_eq!(quote.next_base_fee_stor_ceiling, 9);
+        assert_eq!(quote.max_gas_exec, market::MAX_GAS_EXEC);
+        assert_eq!(quote.max_gas_stor, market::MAX_GAS_STOR);
+    }
+
+    /// The quote is what a wallet prices `max_fee` off, so the reserve it
+    /// implies must be the one admission compares against: one unit of
+    /// headroom below it is exactly what admission rejects.
+    #[test]
+    fn a_reserve_computed_from_the_quote_matches_the_one_admission_uses() {
+        let state = initial_state();
+        let (from, sign_key) = funded();
+        let quote = fee_quote(&state);
+        let build = |max_fee: u128| {
+            create_transaction_native_token_transfer_with_fees(
+                from,
+                0,
+                recipient(),
+                10,
+                &sign_key,
+                FeeDeclaration::new(from, TEST_GAS_LIMIT, 3, max_fee),
+            )
+        };
+
+        let probe = build(u128::MAX >> 1);
+        let by_hand = u128::from(TEST_GAS_LIMIT) * u128::from(quote.base_fee_exec)
+            + u128::from(wire_size(&probe)) * u128::from(quote.base_fee_stor)
+            + 3;
+
+        // The wire size is invariant under max_fee (u128 is fixed-width), so
+        // the reserve computed off the probe prices the tight build too.
+        screen(&build(by_hand), &state).expect("max_fee equal to the reserve is admitted");
+        assert!(matches!(
+            screen(&build(by_hand - 1), &state).expect_err("one unit short"),
+            AdmissionRejection::MaxFeeBelowReserve { .. }
+        ));
+    }
+}

--- a/lez/sequencer/core/src/lib.rs
+++ b/lez/sequencer/core/src/lib.rs
@@ -56,6 +56,7 @@ pub mod block_store;
 pub mod committee_discovery;
 pub mod config;
 pub mod cross_zone_watcher;
+pub mod fees;
 pub mod gossip;
 
 #[cfg(feature = "mock")]
@@ -96,6 +97,43 @@ type FoundingStake = (
     lee::PublicKey,
     lee::Signature,
 );
+
+/// The block's declared-gas budget: the sum of included charged transactions'
+/// signed limits, tracked against the caps the transition enforces on actuals.
+/// Each transaction's actual gas is bounded by its declared gas, so a block
+/// built under this budget can never breach the consensus caps — and no
+/// execution is wasted discovering that.
+#[derive(Clone, Copy, Debug, Default)]
+struct DeclaredGasBudget {
+    exec: u64,
+    stor: u64,
+}
+
+impl DeclaredGasBudget {
+    /// Whether `view`'s declared gas fits the remaining budget.
+    ///
+    /// Saturating rather than checked: a sum that saturates is past its cap
+    /// by construction, so the answer is the same and nothing can panic.
+    const fn fits(self, view: &fee_core::assess::FeeTxView) -> bool {
+        self.exec.saturating_add(view.gas_limit()) <= fee_core::market::MAX_GAS_EXEC
+            && self.stor.saturating_add(view.gas_stor()) <= fee_core::market::MAX_GAS_STOR
+    }
+
+    /// Whether `view` fits an empty budget at all — i.e. its declared gas is
+    /// within the per-block caps. A charged transaction that fails this can
+    /// never be included in any block, so it must be dropped rather than
+    /// deferred (a deferral would repeat for ever).
+    const fn fits_empty(view: &fee_core::assess::FeeTxView) -> bool {
+        view.gas_limit() <= fee_core::market::MAX_GAS_EXEC
+            && view.gas_stor() <= fee_core::market::MAX_GAS_STOR
+    }
+
+    /// Adds a contribution [`Self::fits`] has already cleared.
+    const fn add(&mut self, view: &fee_core::assess::FeeTxView) {
+        self.exec = self.exec.saturating_add(view.gas_limit());
+        self.stor = self.stor.saturating_add(view.gas_stor());
+    }
+}
 
 /// The origin of a transaction.
 #[derive(Clone, Copy)]
@@ -1151,14 +1189,9 @@ impl<BP: BlockPublisherTrait, S: StorageActorTrait> SequencerCore<BP, S> {
             self.store.signing_key(),
         ));
 
-        // TODO: can be a helper impl in V03State
-        let opening = fee_core::state::FeeState::from_bytes(
-            &working_state
-                .get_account_by_id(system_accounts::fee_state_account_id())
-                .data
-                .into_inner(),
-        );
+        let opening = chain_state::apply::opening_fee_state(&working_state);
         let mut summary = fee_core::BlockFeeSummary::default();
+        let mut gas_budget = DeclaredGasBudget::default();
         // The fee tx's summary is only known after the loop; a default-summary
         // placeholder sizes identically (the summary struct is fixed-size).
         let placeholder_fee_lee_tx = LeeTransaction::Public(fee_invocation(
@@ -1257,6 +1290,50 @@ impl<BP: BlockPublisherTrait, S: StorageActorTrait> SequencerCore<BP, S> {
                 continue;
             }
 
+            // Declared-gas pre-screen: a charged transaction whose signed
+            // limits do not fit this block's remaining budget is deferred with
+            // nothing executed, mirroring the size deferral above — unless they
+            // exceed the caps outright, in which case it fits no budget and is
+            // dropped rather than deferred for ever (the RPC door screens these
+            // out, but gossip ingest does not). One that does not even classify
+            // (an unserializable transaction) falls through: the settlement
+            // below rejects it and it is dropped like any other failed
+            // application.
+            let charged_view = match chain_state::classify::classify(&tx, false, &working_state) {
+                Ok(chain_state::classify::FeeClass::Charged(view)) => Some(view),
+                Ok(chain_state::classify::FeeClass::Exempt) | Err(_) => None,
+            };
+            if let Some(view) = &charged_view
+                && !gas_budget.fits(view)
+            {
+                // A transaction whose declared gas exceeds the caps fits no
+                // budget, not even an empty one, so deferring it would stall the
+                // builder behind it for ever. The RPC door screens these out,
+                // but gossip ingest does not, so drop it here instead.
+                if !DeclaredGasBudget::fits_empty(view) {
+                    error!(
+                        "Transaction with hash {tx_hash} declares gas beyond the block caps \
+                         (limit {}, bytes {}); dropping it rather than stalling production",
+                        view.gas_limit(),
+                        view.gas_stor(),
+                    );
+                    self.count_dispatch_failure(&tx).await;
+                    continue;
+                }
+                warn!(
+                    "Transaction with hash {tx_hash} deferred to next block: declared gas \
+                     (limit {}, bytes {}) would exceed the block gas caps",
+                    view.gas_limit(),
+                    view.gas_stor(),
+                );
+                // Anything drained from the store needs no requeue: its record
+                // stays there and is drained again on the next turn.
+                if !from_store {
+                    self.mempool.push_front((origin, tx));
+                }
+                break;
+            }
+
             let before_tx_apply = Instant::now();
             let applied = Self::apply_mempool_transaction(
                 &mut working_state,
@@ -1270,6 +1347,9 @@ impl<BP: BlockPublisherTrait, S: StorageActorTrait> SequencerCore<BP, S> {
                 &mut summary,
             );
             if applied {
+                if let Some(view) = &charged_view {
+                    gas_budget.add(view);
+                }
                 sequencer_core_metrics::record_mempool_transaction_application_time(
                     origin.into(),
                     tx.kind().into(),

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -1202,13 +1202,23 @@ async fn a_block_full_of_declared_gas_defers_the_rest() {
             .unwrap();
     }
 
-    let block_id = sequencer.produce_new_block().await.unwrap();
-    let block = sequencer.store.get_block_at_id(block_id).unwrap().unwrap();
+    let block_id = sequencer.run_production_turn().await.unwrap();
+    let block = sequencer
+        .store
+        .block_at_id(block_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_block_tail(&block, &transfers[..5]);
 
     // Deferred, not dropped: the sixth leads the next block.
-    let block_id = sequencer.produce_new_block().await.unwrap();
-    let block = sequencer.store.get_block_at_id(block_id).unwrap().unwrap();
+    let block_id = sequencer.run_production_turn().await.unwrap();
+    let block = sequencer
+        .store
+        .block_at_id(block_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_block_tail(&block, &transfers[5..]);
 }
 
@@ -1248,13 +1258,23 @@ async fn an_over_cap_transaction_is_dropped_not_deferred() {
 
     // The over-cap tx is dropped and the normal transfer still makes the block:
     // the builder did not stall behind the unfittable transaction.
-    let block_id = sequencer.produce_new_block().await.unwrap();
-    let block = sequencer.store.get_block_at_id(block_id).unwrap().unwrap();
+    let block_id = sequencer.run_production_turn().await.unwrap();
+    let block = sequencer
+        .store
+        .block_at_id(block_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_block_tail(&block, std::slice::from_ref(&normal));
 
     // Nothing was deferred: the next block carries no user transactions.
-    let block_id = sequencer.produce_new_block().await.unwrap();
-    let block = sequencer.store.get_block_at_id(block_id).unwrap().unwrap();
+    let block_id = sequencer.run_production_turn().await.unwrap();
+    let block = sequencer
+        .store
+        .block_at_id(block_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_block_tail(&block, &[]);
 }
 

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -1177,6 +1177,87 @@ async fn a_delivery_backlog_is_spread_across_blocks() {
     assert_eq!(dispatches_in(&block).len(), 3);
 }
 
+#[tokio::test]
+async fn a_block_full_of_declared_gas_defers_the_rest() {
+    let (mut sequencer, mempool_handle) = common_setup().await;
+    let acc1 = initial_public_user_accounts()[0].account_id;
+    let acc2 = initial_public_user_accounts()[1].account_id;
+    let sign_key = create_signing_key_for_account1();
+
+    // Six transfers declaring the default 2M-cycle test gas limit each: five
+    // fill the 10M-cycle block execution budget exactly, so the sixth does
+    // not fit however few cycles the transfers actually use — the budget
+    // prices declared gas, not metered gas.
+    let transfers: Vec<_> = (0..6_u128)
+        .map(|nonce| {
+            common::test_utils::create_transaction_native_token_transfer(
+                acc1, nonce, acc2, 10, &sign_key,
+            )
+        })
+        .collect();
+    for tx in &transfers {
+        mempool_handle
+            .push((TransactionOrigin::User, tx.clone()))
+            .await
+            .unwrap();
+    }
+
+    let block_id = sequencer.produce_new_block().await.unwrap();
+    let block = sequencer.store.get_block_at_id(block_id).unwrap().unwrap();
+    assert_block_tail(&block, &transfers[..5]);
+
+    // Deferred, not dropped: the sixth leads the next block.
+    let block_id = sequencer.produce_new_block().await.unwrap();
+    let block = sequencer.store.get_block_at_id(block_id).unwrap().unwrap();
+    assert_block_tail(&block, &transfers[5..]);
+}
+
+#[tokio::test]
+async fn an_over_cap_transaction_is_dropped_not_deferred() {
+    // C1: a charged transaction whose declared gas exceeds the caps fits no
+    // budget, not even an empty one. The RPC door screens these out, but gossip
+    // ingest does not, so the builder must DROP it — deferring it would stall
+    // every subsequent block behind it. A normal transfer queued after it must
+    // still make the block.
+    let (mut sequencer, mempool_handle) = common_setup().await;
+    let acc1 = initial_public_user_accounts()[0].account_id;
+    let acc2 = initial_public_user_accounts()[1].account_id;
+    let sign_key = create_signing_key_for_account1();
+
+    // Declares exec gas one cycle beyond the per-block cap, so it can never fit
+    // any block. Origin `Gossip` stands in for the unscreened ingest path.
+    let over_cap = common::test_utils::create_transaction_native_token_transfer_with_fees(
+        acc1,
+        0,
+        acc2,
+        10,
+        &sign_key,
+        lee::FeeDeclaration::new(acc1, fee_core::market::MAX_GAS_EXEC + 1, 0, u128::MAX >> 1),
+    );
+    let normal =
+        common::test_utils::create_transaction_native_token_transfer(acc1, 0, acc2, 10, &sign_key);
+
+    mempool_handle
+        .push((TransactionOrigin::Gossip, over_cap))
+        .await
+        .unwrap();
+    mempool_handle
+        .push((TransactionOrigin::User, normal.clone()))
+        .await
+        .unwrap();
+
+    // The over-cap tx is dropped and the normal transfer still makes the block:
+    // the builder did not stall behind the unfittable transaction.
+    let block_id = sequencer.produce_new_block().await.unwrap();
+    let block = sequencer.store.get_block_at_id(block_id).unwrap().unwrap();
+    assert_block_tail(&block, std::slice::from_ref(&normal));
+
+    // Nothing was deferred: the next block carries no user transactions.
+    let block_id = sequencer.produce_new_block().await.unwrap();
+    let block = sequencer.store.get_block_at_id(block_id).unwrap().unwrap();
+    assert_block_tail(&block, &[]);
+}
+
 #[test]
 fn transaction_pre_check_pass() {
     let tx = common::test_utils::produce_dummy_empty_transaction();

--- a/lez/sequencer/service/protocol/Cargo.toml
+++ b/lez/sequencer/service/protocol/Cargo.toml
@@ -15,3 +15,7 @@ lee_core.workspace = true
 hex.workspace = true
 serde.workspace = true
 serde_with.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/lez/sequencer/service/protocol/src/fees.rs
+++ b/lez/sequencer/service/protocol/src/fees.rs
@@ -1,0 +1,147 @@
+//! Fee admission rejections and the fee-market quote, as RPC wire types.
+
+use lee::AccountId;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Why a submitted transaction was refused at the fee-admission door.
+///
+/// Each arm carries the values that decided it, and rides in the JSON-RPC
+/// error's `data` field so a client reads them structurally rather than out of
+/// the rendered reason. The door is anti-spam, not consensus: the block
+/// transition enforces the same rules (and the payer-balance check's
+/// block-level counterpart, the reserve debit) authoritatively.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+pub enum AdmissionRejection {
+    #[error("data_bytes {data_bytes} outside 1..={max}")]
+    DataBytesOutOfRange { data_bytes: u64, max: u64 },
+    #[error("gas_limit {gas_limit} above the block cap {max}")]
+    GasLimitExceedsMax { gas_limit: u64, max: u64 },
+    #[error("max_fee {max_fee} below the fee reserve {fee_reserve}")]
+    MaxFeeBelowReserve { fee_reserve: u128, max_fee: u128 },
+    #[error("designated payer {payer:?} authorized nothing in this transaction")]
+    UnauthorizedPayer { payer: AccountId },
+    #[error("payer {payer:?} holds {balance} but the fee reserve is {fee_reserve}")]
+    PayerCannotFund {
+        payer: AccountId,
+        balance: u128,
+        fee_reserve: u128,
+    },
+    #[error("a public transaction must declare a fee")]
+    MissingFeeDeclaration,
+    #[error("fee-invalid: {reason}")]
+    OtherFeeValidity { reason: String },
+}
+
+impl AdmissionRejection {
+    /// The JSON-RPC error code this rejection is returned under. One stable
+    /// code per arm, in the `-31_980..` band reserved for fee admission.
+    #[must_use]
+    pub const fn code(&self) -> i32 {
+        match self {
+            Self::DataBytesOutOfRange { .. } => -31_980,
+            Self::GasLimitExceedsMax { .. } => -31_981,
+            Self::MaxFeeBelowReserve { .. } => -31_982,
+            Self::UnauthorizedPayer { .. } => -31_983,
+            Self::PayerCannotFund { .. } => -31_984,
+            Self::OtherFeeValidity { .. } => -31_985,
+            Self::MissingFeeDeclaration => -31_986,
+        }
+    }
+}
+
+/// The fee market priced off the head state, for wallets sizing `max_fee`.
+///
+/// The next-block figures are a band rather than an estimate: the block being
+/// filled is not observable at query time, so the quote steps the market once
+/// at an empty block (floor) and once at a block filled to its caps (ceiling);
+/// every possible next-block base fee lies between them. Fee-exempt classes
+/// (private transactions, deployments) pay nothing under the interim policy
+/// and are not quoted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeeStateQuote {
+    /// The block height the quoted state settled at, for staleness checks.
+    pub height: u64,
+    pub base_fee_exec: u64,
+    pub base_fee_stor: u64,
+    pub next_base_fee_exec_floor: u64,
+    pub next_base_fee_exec_ceiling: u64,
+    pub next_base_fee_stor_floor: u64,
+    pub next_base_fee_stor_ceiling: u64,
+    pub max_gas_exec: u64,
+    pub max_gas_stor: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn every_rejection() -> Vec<AdmissionRejection> {
+        let payer = AccountId::new([7_u8; 32]);
+        vec![
+            AdmissionRejection::DataBytesOutOfRange {
+                data_bytes: 0,
+                max: 1_000_000,
+            },
+            AdmissionRejection::GasLimitExceedsMax {
+                gas_limit: 10_000_001,
+                max: 10_000_000,
+            },
+            AdmissionRejection::MaxFeeBelowReserve {
+                fee_reserve: 401_600,
+                max_fee: 1,
+            },
+            AdmissionRejection::UnauthorizedPayer { payer },
+            AdmissionRejection::PayerCannotFund {
+                payer,
+                balance: 0,
+                fee_reserve: 401_600,
+            },
+            AdmissionRejection::MissingFeeDeclaration,
+            AdmissionRejection::OtherFeeValidity {
+                reason: "reason".to_owned(),
+            },
+        ]
+    }
+
+    #[test]
+    fn every_rejection_roundtrips_through_json() {
+        for rejection in every_rejection() {
+            let json = serde_json::to_string(&rejection).expect("serializes");
+            let back: AdmissionRejection = serde_json::from_str(&json)
+                .unwrap_or_else(|err| panic!("rejection {rejection:?} does not roundtrip: {err}"));
+            assert_eq!(back, rejection);
+        }
+    }
+
+    #[test]
+    fn rejection_codes_are_unique_and_in_band() {
+        let codes: Vec<i32> = every_rejection()
+            .iter()
+            .map(AdmissionRejection::code)
+            .collect();
+        let mut deduped = codes.clone();
+        deduped.sort_unstable();
+        deduped.dedup();
+        assert_eq!(deduped.len(), codes.len(), "codes must be unique");
+        assert!(codes.iter().all(|code| (-31_989..=-31_980).contains(code)));
+    }
+
+    #[test]
+    fn quote_roundtrips_through_json() {
+        let quote = FeeStateQuote {
+            height: 5,
+            base_fee_exec: 8,
+            base_fee_stor: 8,
+            next_base_fee_exec_floor: 8,
+            next_base_fee_exec_ceiling: 9,
+            next_base_fee_stor_floor: 8,
+            next_base_fee_stor_ceiling: 9,
+            max_gas_exec: 10_000_000,
+            max_gas_stor: 1_000_000,
+        };
+        let json = serde_json::to_string(&quote).expect("serializes");
+        let back: FeeStateQuote = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, quote);
+    }
+}

--- a/lez/sequencer/service/protocol/src/lib.rs
+++ b/lez/sequencer/service/protocol/src/lib.rs
@@ -3,10 +3,13 @@
 use std::{fmt::Display, str::FromStr};
 
 pub use common::{HashType, block::Block, transaction::LeeTransaction};
+pub use fees::{AdmissionRejection, FeeStateQuote};
 pub use lee::{Account, AccountId, ProgramId};
 pub use lee_core::{BlockId, Commitment, CommitmentSetDigest, MembershipProof, account::Nonce};
 use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+mod fees;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeDisplay, DeserializeFromStr)]
 pub struct ChannelId(pub [u8; 32]);

--- a/lez/sequencer/service/rpc/src/lib.rs
+++ b/lez/sequencer/service/rpc/src/lib.rs
@@ -7,7 +7,8 @@ use jsonrpsee::types::ErrorObjectOwned;
 pub use jsonrpsee::{core::ClientError, http_client::HttpClientBuilder as SequencerClientBuilder};
 use sequencer_service_protocol::{
     Account, AccountId, Block, BlockId, ChannelId, Commitment, CommitmentSetDigest,
-    CrossZoneDeadLetterReport, HashType, LeeTransaction, MembershipProof, Nonce, ProgramId,
+    CrossZoneDeadLetterReport, FeeStateQuote, HashType, LeeTransaction, MembershipProof, Nonce,
+    ProgramId,
 };
 
 #[cfg(all(not(feature = "server"), not(feature = "client")))]
@@ -38,6 +39,11 @@ pub type SequencerClient = jsonrpsee::http_client::HttpClient;
 pub trait Rpc {
     #[method(name = "sendTransaction")]
     async fn send_transaction(&self, tx: LeeTransaction) -> Result<HashType, ErrorObjectOwned>;
+
+    /// The head fee market: current base fees and the band the next block's
+    /// can move within, for sizing `max_fee` at submission time.
+    #[method(name = "getFeeState")]
+    async fn get_fee_state(&self) -> Result<FeeStateQuote, ErrorObjectOwned>;
 
     // TODO: expand healthcheck response into some kind of report
     #[method(name = "checkHealth")]


### PR DESCRIPTION
# feat(fees): admission screen, getFeeState RPC, and mempool cap budgeting

## 🎯 Purpose

Seventh PR of the fee-subsystem train (#746 → #747 → #750 → #752 → #753 → #754 → **#758** → #762). With #754 the block transition charges fees authoritatively; what was still missing was everything *around* that authority:

1. A fee-invalid transaction (zero `max_fee`, unfundable payer, oversized gas limit, …) was accepted at `sendTransaction`, gossiped to peers, and sat in the mempool forever while the client watched it silently never land.
2. Wallets had no way to learn the current base fees or the block gas caps, so they could not size `max_fee` at all.
3. The block builder discovered the per-block gas caps only *after* executing a transaction (`ExecGasCapExceeded` at settlement), wasting the execution and dropping the transaction.

This PR closes all three: a **fee-admission door** at RPC ingest, a **`getFeeState`** quote RPC, and **declared-gas budgeting** in the block builder. Admission is deliberately **anti-spam, not consensus** — the block transition remains the sole authority; the door only turns away transactions no block could ever include, and tells the client which rule they broke.

## ⚙️ Approach

**Wire types** (`lez/sequencer/service/protocol/src/fees.rs`, new):

- `AdmissionRejection` — 7 arms (`DataBytesOutOfRange`, `GasLimitExceedsMax`, `MaxFeeBelowReserve`, `FeeWitnessOnly`, `UnauthorizedPayer`, `PayerCannotFund`, `OtherFeeValidity`), each carrying the values that decided it and each mapped to a stable JSON-RPC error code in the reserved `-31_980..=-31_986` band. The structured rejection rides in the error's `data` field so clients read it structurally instead of parsing prose.
- `FeeStateQuote` — the current base fees plus a floor/ceiling **band** for the next block's fees (the block being filled is unobservable at query time, so the market is stepped once at an empty block and once at a cap-full block; every possible next-block base fee lies between), the settled `height` for staleness checks, and the block gas caps — exactly what a wallet needs to size `max_fee`.

**The screen** (`lez/sequencer/core/src/fees.rs`, new): `screen(tx, state)` mirrors the settlement's check order (`validate_static_tx` for data-bytes range, gas-limit cap, `max_fee >= fee_reserve`), then the signer/payer-authorization checks, then the one check only a live state can answer: payer balance vs. the fee reserve. Fee-exempt classes (private transactions, deployments, full vault sweeps) pass unscreened. Two verdicts are advisory by nature (base fees and balances move) and documented as such. `fee_quote(state)` prices the band through the same `fee_core::market` arithmetic the block transition moves the real fee state with.

**Wiring**: the screen runs in the executor actor's `Transaction` handler against the head state, and the verdict returns as a typed reply — `SubmitOutcome::{Admitted, Rejected(AdmissionRejection)}` — rather than an actor failure. The RPC service renders a rejection as `rejection_error()` (own code + rendered reason + structured `data`). The gossip publish was **moved after the admission verdict**, so refused spam is never propagated to peers (and a full-mempool error has already returned by then, so no publish can be lost to it either).

**Mempool cap budgeting** (`lez/sequencer/core/src/lib.rs`): the builder tracks a `DeclaredGasBudget` — the running sum of included charged transactions' declared `gas_limit`/`data_bytes` against `MAX_GAS_EXEC`/`MAX_GAS_STOR` — **before** executing. A charged transaction that doesn't fit is deferred (`push_front` + stop filling, mirroring the existing size-deferral precedent) with nothing executed. Since actual gas ≤ declared gas per transaction, a block built under this budget can never breach the consensus caps: the settle-path cap error becomes unreachable in the builder and no execution is wasted. Static validity bounds every charged tx by the caps, so a lone tx always fits an empty budget and deferral never loops forever.

**Deliberate divergences** (documented at the code sites): there is no `ExceedsBlockCap` rejection arm and no private-fee quote — under the interim policy exempt transactions contribute no gas and pay nothing, and static validity already bounds charged transactions by the caps. Oversized deployments are admitted (exempt *and* uncapped; bounded only by the ingest size check).

- [x] Add `AdmissionRejection` (7 arms, stable codes -31_980..=-31_986) and `FeeStateQuote` wire types to `sequencer_service_protocol`
- [x] Add `sequencer_core::fees::{screen, fee_quote}` mirroring the settlement's check order plus the live payer-affordability check
- [x] Wire the screen into the executor actor's `Transaction` handler with a typed `SubmitOutcome` reply; render rejections as structured JSON-RPC errors
- [x] Move the gossip publish after the admission verdict so refused transactions are not propagated
- [x] Add the `getFeeState` RPC method (client generated for the wallet automatically by the jsonrpsee macro)
- [x] Add declared-gas budgeting to the block builder: defer-not-drop when a charged tx's declared gas would exceed the block caps
- [x] Extract `chain_state::apply::opening_fee_state` and reuse it at all three fee-state read sites

## 🧪 How to Test

Mirror CI locally:

```sh
cargo +nightly fmt --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
taplo fmt --check && cargo machete && cargo deny check

# unit suites (fees screen/quote, executor admission, builder deferral, wire-type roundtrips)
RISC0_DEV_MODE=1 cargo nextest run --workspace --exclude integration_tests --exclude test_fixtures --all-features
```

Highlights to look at:

- `sequencer_core::fees::tests` — every rejection arm has a positive/negative test, and each rejected case cross-checks `settle_verdict` so admission is provably no *looser* than the block transition for the shared checks; `a_reserve_computed_from_the_quote_matches_the_one_admission_uses` pins that a wallet pricing off the quote lands exactly on the admission threshold.
- `a_block_full_of_declared_gas_defers_the_rest` (`sequencer_core::tests`) — six 2M-limit transfers: five fill the 10M budget exactly, the sixth leads the *next* block (deferred, not dropped).
- `handle_transaction_rejects_a_fee_invalid_submission` (executor actor) — the rejection comes back as a reply, not an error.

**Note:** the integration suites still assert pre-fee balances and submit zero-fee raw transactions, so this door breaks several of them by design; their fee-aware conversion (fixture rescale included) lands in #762, stacked on this PR. Run them there.

## 🔗 Dependencies

- #754 (`erhant/fees/actually-charge-txes`) — the settlement/charging layer this door fronts. Merge the train in order: #746 → #747 → #750 → #752 → #753 → #754 → #758.

## 🔜 Future Work

- **Fee-aware integration suite** (#762, stacked on this PR): fixture balance rescale to LGO scale, fee-aware assertions, admission-rejection tests, and the account-less-invocation findings it surfaces.
- **Wallet-side gas estimation.** The default wallet `gas_limit` (2M) means a block carries at most 5 charged wallet transactions against the 10M cap. Wallets should size `gas_limit` from `getFeeState` plus per-program estimation instead of a flat default.
- Revisit the divergences when the interim policy ends: if exempt classes ever contribute gas or private transactions are charged, admission needs an `ExceedsBlockCap`-style arm and the quote needs private pricing.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments