### PR TITLE
test: Chained-caller and second-mover test prerequisites

### DIFF
--- a/integration_tests/cucumber_tests/cucumber.rs
+++ b/integration_tests/cucumber_tests/cucumber.rs
@@ -16,6 +16,7 @@ use integration_tests::cucumber::{
     default::{
         ARTEFACTS, CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL, MAX_CUCUMBER_CONCURRENT_SCENARIOS,
         RUST_LOG, TF_KEEP_LOGS, create_scenario_output_dir, get_feature_path, get_retries,
+        get_tag_filter,
     },
     world::CucumberWorld,
 };
@@ -104,54 +105,67 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     let teardown_failure_flag = Arc::clone(&teardown_failed);
-    let failed = world
-        .after(move |feature, _rule, scenario, scenario_finished, world| {
-            let teardown_failure_flag = Arc::clone(&teardown_failure_flag);
-            Box::pin(async move {
-                // Runs after the scenario has completed; useful for capturing final state/logs.
-                info!(target: TARGET,
-                    "\nFinished - {}: {} ({}: {})\n",
-                    scenario.keyword, scenario.name, feature.keyword, feature.name,
-                );
+    let runner = world.after(move |feature, _rule, scenario, scenario_finished, world| {
+        let teardown_failure_flag = Arc::clone(&teardown_failure_flag);
+        Box::pin(async move {
+            // Runs after the scenario has completed; useful for capturing final state/logs.
+            info!(target: TARGET,
+                "\nFinished - {}: {} ({}: {})\n",
+                scenario.keyword, scenario.name, feature.keyword, feature.name,
+            );
 
-                if let Some(world) = world {
-                    let path = world.scenario_base_dir.join("debug_dump_file.log");
-                    if let Some(parent) = path.parent() {
-                        let _unused = std::fs::create_dir_all(parent);
-                    }
-                    let _initial_debug_write = std::fs::write(&path, world.full_debug_info_string());
+            if let Some(world) = world {
+                let path = world.scenario_base_dir.join("debug_dump_file.log");
+                if let Some(parent) = path.parent() {
+                    let _unused = std::fs::create_dir_all(parent);
+                }
+                let _initial_debug_write = std::fs::write(&path, world.full_debug_info_string());
 
-                    let teardown_result = world.stop_runtime().await;
-                    if let Err(error) = &teardown_result {
-                        teardown_failure_flag.store(true, std::sync::atomic::Ordering::Relaxed);
-                        warn!(target: TARGET, "Cucumber runtime teardown failed: {error}");
-                    }
+                let teardown_result = world.stop_runtime().await;
+                if let Err(error) = &teardown_result {
+                    teardown_failure_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                    warn!(target: TARGET, "Cucumber runtime teardown failed: {error}");
+                }
 
-                    // Rewrite the dump after teardown so teardown state and
-                    // any teardown error are retained for diagnostics. The
-                    // first write above deliberately captures the live
-                    // runtime state before handles are released.
-                    let _final_debug_write = std::fs::write(&path, world.full_debug_info_string());
+                // Rewrite the dump after teardown so teardown state and
+                // any teardown error are retained for diagnostics. The
+                // first write above deliberately captures the live
+                // runtime state before handles are released.
+                let _final_debug_write = std::fs::write(&path, world.full_debug_info_string());
 
-                    if teardown_result.is_ok()
-                        && matches!(scenario_finished, ScenarioFinished::StepPassed)
-                        && is_truthy_env(CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL)
-                    {
-                        info!(target: TARGET,
-                            "Env var '{CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL}' set, removing all \
-                            artefacts\n"
-                        );
-                        if let Err(e) = world.clear_scenario_artifacts() {
-                            warn!(target: TARGET, "{e}");
-                        }
+                if teardown_result.is_ok()
+                    && matches!(scenario_finished, ScenarioFinished::StepPassed)
+                    && is_truthy_env(CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL)
+                {
+                    info!(target: TARGET,
+                        "Env var '{CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL}' set, removing all \
+                        artefacts\n"
+                    );
+                    if let Err(e) = world.clear_scenario_artifacts() {
+                        warn!(target: TARGET, "{e}");
                     }
                 }
-            })
+            }
         })
-        // Runs Cucumber. Features sourced from a Parser are fed to a Runner, which
-        // produces events handled by a Writer.
-        .run(get_feature_path()?)
-        .await;
+    });
+
+    // Runs Cucumber. Features sourced from a Parser are fed to a Runner, which
+    // produces events handled by a Writer. `CUCUMBER_TAGS`, when set, restricts
+    // the run to scenarios carrying one of the listed tags.
+    let feature_path = get_feature_path()?;
+    let failed = if let Some(tags) = get_tag_filter() {
+        info!(target: TARGET, "Restricting run to scenarios tagged: {tags:?}");
+        runner
+            .filter_run(feature_path, move |feature, rule, scenario| {
+                let matches = |candidate: &String| tags.iter().any(|wanted| wanted == candidate);
+                scenario.tags.iter().any(&matches)
+                    || feature.tags.iter().any(&matches)
+                    || rule.is_some_and(|rule| rule.tags.iter().any(&matches))
+            })
+            .await
+    } else {
+        runner.run(feature_path).await
+    };
 
     // Clean up manually reserved handshake port block files for this process
     release_reserved_port_block();

--- a/integration_tests/cucumber_tests/features/sequencer_registration.feature
+++ b/integration_tests/cucumber_tests/features/sequencer_registration.feature
@@ -24,11 +24,15 @@ Feature: Sequencer registration — a first Stake turns balance into stake
   # dropped with a reason), replace the two-block window with it.
   #
   # Registration cases not ported:
-  # - P-15, P-16 need a bad-mover guest
-  # - P-17, P-19 need a chained-caller guest
-  # - P-21 needs a second mover program fitting Stake's two-account slot
-  # - G-01..G-03 exercise genesis builders private to sequencer_core, where
-  #   G-01 and G-02 are already covered
+  # - P-15, P-16 need no new test program: the mover instruction data is
+  #   caller-controlled and opaque to sequencer_stake, so authenticated_transfer
+  #   can be told to move a different amount than the Stake declares
+  # - P-19 needs a ConfirmStake chained from another program, rejected by the
+  #   self-caller guard; the stake_chain_caller program supports it
+  # - G-01..G-03 exercise genesis builders private to sequencer_core
+  #
+  # P-17 and P-21 deploy a test program at runtime (a program deployment
+  # transaction), since test guests are not in the node's compiled-in set.
 
   Background:
     Given a LEZ stack with fast blocks and configured public accounts
@@ -118,6 +122,19 @@ Feature: Sequencer registration — a first Stake turns balance into stake
     Then the stake transaction is not included in a block
     And the stake accounts are unchanged
 
+  @stake_registration_ci @P-17 @P1 @L3
+  # In-program reason: "Stake is only invoked as a top-level user
+  # transaction". The stake_chain_caller test program (deployed at runtime)
+  # forwards an otherwise well-formed Stake into sequencer_stake as a chained
+  # call, so the caller-is-none guard is the only assert that can reject it.
+  Scenario: Stake invoked as a chained call is rejected
+    Given the stake_chain_caller test program is deployed
+    When a Stake of "twice the minimum stake" is submitted as a chained call through the stake_chain_caller program
+    Then the stake transaction is not included in a block
+    And the ownership account is not claimed
+    And the config has no entry for the sequencer key
+    And the stake accounts are unchanged
+
   @stake_registration_ci @P-20 @P2 @L3
   # In-program reason: "Stake requires a funding account, an ownership
   # account, and the config account".
@@ -130,6 +147,20 @@ Feature: Sequencer registration — a first Stake turns balance into stake
       | count |
       | 2     |
       | 4     |
+
+  @stake_registration_ci @P-21 @P2 @L3
+  # Stake is generic over its mover. The simple_balance_transfer test program
+  # (deployed at runtime) is a native two-account transfer distinct from
+  # authenticated_transfer; the funding account is claimed under it so it may
+  # debit it.
+  Scenario: Registration through a second mover program is accepted
+    Given the simple_balance_transfer test program is deployed
+    And a funding account owned by the simple_balance_transfer program holding "twice the minimum stake"
+    When a Stake of "twice the minimum stake" is submitted with simple_balance_transfer as the mover
+    Then the stake transaction is accepted
+    And the config entry tracks the staked amount with no pending unstake
+    And the ownership account balance increased by the staked amount
+    And the funding account balance decreased by the staked amount
 
   @stake_registration_ci @P-23 @P1 @L3
   # ⚠️ Diverges further from the plan than the earlier L1 port did. The plan

--- a/integration_tests/src/cucumber/context.rs
+++ b/integration_tests/src/cucumber/context.rs
@@ -272,6 +272,15 @@ impl LezScenarioContext {
             .map_err(StepError::query_failed_boxed)
     }
 
+    /// Deploys a program at runtime by submitting its bytecode through the
+    /// scenario wallet; returns the submission hash.
+    pub async fn deploy_program(&self, bytecode: Vec<u8>) -> Result<HashType, StepError> {
+        self.wallet()
+            .send_program_deployment_transaction(bytecode)
+            .await
+            .map_err(StepError::query_failed_boxed)
+    }
+
     /// Executes an authenticated public transfer using wallet-resolved labels.
     pub async fn public_transfer_by_labels(
         &self,

--- a/integration_tests/src/cucumber/default.rs
+++ b/integration_tests/src/cucumber/default.rs
@@ -20,6 +20,23 @@ pub const RUST_LOG: &str = "RUST_LOG";
 pub const CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL: &str = "CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL";
 /// Environment variable selecting an existing node deployment configuration.
 pub const CUCUMBER_NODE_CONFIG_OVERRIDE: &str = "CUCUMBER_NODE_CONFIG_OVERRIDE";
+/// Environment variable restricting the run to scenarios carrying one of a
+/// comma-separated list of tags (a leading `@` is optional). Unset runs every
+/// scenario. Example: `CUCUMBER_TAGS=@P-17,@P-21`.
+pub const CUCUMBER_TAGS: &str = "CUCUMBER_TAGS";
+
+/// Parses [`CUCUMBER_TAGS`] into the tags to keep (leading `@` stripped);
+/// `None` when unset or empty, meaning run every scenario.
+#[must_use]
+pub fn get_tag_filter() -> Option<Vec<String>> {
+    let tags: Vec<String> = std::env::var(CUCUMBER_TAGS)
+        .ok()?
+        .split(',')
+        .map(|tag| tag.trim().trim_start_matches('@').to_owned())
+        .filter(|tag| !tag.is_empty())
+        .collect();
+    (!tags.is_empty()).then_some(tags)
+}
 
 /// Installs the Cucumber tracing subscriber using `RUST_LOG` or an `info` default.
 pub fn init_tracing() {

--- a/integration_tests/src/cucumber/stake_scenario.rs
+++ b/integration_tests/src/cucumber/stake_scenario.rs
@@ -254,14 +254,57 @@ pub fn stake_instruction(
     sequencer_key: SequencerKey,
     amount: u128,
 ) -> Result<InstructionData, StepError> {
+    stake_instruction_with_mover(
+        sequencer_key,
+        amount,
+        programs::authenticated_transfer().id(),
+        transfer_instruction(amount)?,
+    )
+}
+
+/// Serialized `sequencer_stake::Stake` for `sequencer_key` driven by an
+/// arbitrary mover.
+///
+/// The mover is the program `Stake` chains into to move `amount` into the
+/// ownership account; `authenticated_transfer` is the default, but `Stake` is
+/// generic over it.
+pub fn stake_instruction_with_mover(
+    sequencer_key: SequencerKey,
+    amount: u128,
+    mover_program_id: lee_core::program::ProgramId,
+    mover_instruction_data: InstructionData,
+) -> Result<InstructionData, StepError> {
     Program::serialize_instruction(sequencer_stake_core::Instruction::Stake {
         sequencer_key,
         amount,
-        mover_program_id: programs::authenticated_transfer().id(),
-        mover_instruction_data: transfer_instruction(amount)?,
+        mover_program_id,
+        mover_instruction_data,
     })
     .map_err(|error| StepError::LogicalError {
         message: format!("failed to serialize the Stake instruction: {error}"),
+    })
+}
+
+/// Serialized instruction for the `stake_chain_caller` test program: forward
+/// `forwarded_instruction_data` to `target_program_id` as a chained call.
+pub fn chain_caller_instruction(
+    target_program_id: lee_core::program::ProgramId,
+    forwarded_instruction_data: InstructionData,
+) -> Result<InstructionData, StepError> {
+    Program::serialize_instruction((target_program_id, forwarded_instruction_data)).map_err(
+        |error| StepError::LogicalError {
+            message: format!("failed to serialize the chain-caller instruction: {error}"),
+        },
+    )
+}
+
+/// Serialized instruction for the `simple_balance_transfer` test program.
+///
+/// Its instruction is a bare `u128` amount. Used both to move `amount` as a
+/// Stake mover and (with any value) to claim a fresh account under the program.
+pub fn simple_balance_transfer_instruction(amount: u128) -> Result<InstructionData, StepError> {
+    Program::serialize_instruction(amount).map_err(|error| StepError::LogicalError {
+        message: format!("failed to serialize the simple_balance_transfer instruction: {error}"),
     })
 }
 

--- a/integration_tests/src/cucumber/steps/stake/actions.rs
+++ b/integration_tests/src/cucumber/steps/stake/actions.rs
@@ -9,7 +9,9 @@ use super::{
 use crate::cucumber::{
     error::{StepError, StepResult},
     stake_scenario::{
-        confirm_stake_instruction, raw_stake_instruction, stake_instruction, transfer_instruction,
+        chain_caller_instruction, confirm_stake_instruction, raw_stake_instruction,
+        simple_balance_transfer_instruction, stake_instruction, stake_instruction_with_mover,
+        transfer_instruction,
     },
     world::CucumberWorld,
 };
@@ -50,6 +52,63 @@ async fn submit_stake(world: &mut CucumberWorld, step: &Step, expression: String
     let scenario = world.stake()?;
     let accounts = stake_accounts(scenario.funding_id()?, scenario.ownership_id()?);
     submit_stake_with_accounts(world, &expression, accounts).await
+}
+
+#[when(
+    expr = "a Stake of {string} is submitted as a chained call through the stake_chain_caller \
+            program"
+)]
+async fn submit_stake_as_chained_call(
+    world: &mut CucumberWorld,
+    step: &Step,
+    expression: String,
+) -> StepResult {
+    log_step(step);
+    let scenario = world.stake()?;
+    let amount = scenario.amount(&expression)?;
+    // A well-formed Stake, submitted to the chain-caller program instead of
+    // top-level: sequencer_stake's `caller_program_id.is_none()` guard is the
+    // only thing that can reject it.
+    let forwarded = stake_instruction(scenario.sequencer_key(), amount)?;
+    let instruction = chain_caller_instruction(programs::sequencer_stake().id(), forwarded)?;
+    let accounts = stake_accounts(scenario.funding_id()?, scenario.ownership_id()?);
+    submit_and_record(
+        world,
+        accounts,
+        instruction,
+        test_programs::stake_chain_caller().id(),
+        amount,
+    )
+    .await
+}
+
+#[when(expr = "a Stake of {string} is submitted with simple_balance_transfer as the mover")]
+async fn submit_stake_with_simple_mover(
+    world: &mut CucumberWorld,
+    step: &Step,
+    expression: String,
+) -> StepResult {
+    log_step(step);
+    let scenario = world.stake()?;
+    let amount = scenario.amount(&expression)?;
+    // simple_balance_transfer moves `amount` from the (mover-owned) funding
+    // account into the ownership account, standing in for authenticated_transfer
+    // as a different mover.
+    let instruction = stake_instruction_with_mover(
+        scenario.sequencer_key(),
+        amount,
+        test_programs::simple_balance_transfer().id(),
+        simple_balance_transfer_instruction(amount)?,
+    )?;
+    let accounts = stake_accounts(scenario.funding_id()?, scenario.ownership_id()?);
+    submit_and_record(
+        world,
+        accounts,
+        instruction,
+        programs::sequencer_stake().id(),
+        amount,
+    )
+    .await
 }
 
 #[when(expr = "a Stake of {string} is submitted without the ownership account's signature")]

--- a/integration_tests/src/cucumber/steps/stake/helpers.rs
+++ b/integration_tests/src/cucumber/steps/stake/helpers.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use common::HashType;
 use futures::future::try_join_all;
-use lee::{Account, AccountId, PublicKey};
+use lee::{Account, AccountId, PublicKey, program::Program};
 use lee_core::program::{InstructionData, ProgramId};
 use sequencer_service_rpc::RpcClient as _;
 use sequencer_stake_core::{SequencerEntry, SequencerKey, SequencerStakeConfig};
@@ -151,6 +151,15 @@ pub(super) async fn submit_and_record(
         submitted_at_block,
     });
     Ok(())
+}
+
+/// Deploys `program`'s bytecode at runtime and waits until the deployment is
+/// included, so the program is registered in state and usable as the target of
+/// a later transaction. Test guests are not in the node's compiled-in program
+/// set, so scenarios that exercise one deploy it first.
+pub(super) async fn deploy_and_wait(context: &LezScenarioContext, program: &Program) -> StepResult {
+    let hash = context.deploy_program(program.elf().to_vec()).await?;
+    wait_for_inclusion(context, hash).await
 }
 
 /// Waits until `hash` appears in a block.

--- a/integration_tests/src/cucumber/steps/stake/setup.rs
+++ b/integration_tests/src/cucumber/steps/stake/setup.rs
@@ -5,17 +5,18 @@
 
 use cucumber::{gherkin::Step, given};
 use lee::Account;
+use wallet::AccountIdentity;
 
 use super::{
     super::log_step,
     helpers::{
-        config_entry, first_configured_public_account, get_account, stake_config,
-        submit_accepted_stake,
+        config_entry, deploy_and_wait, first_configured_public_account, get_account, stake_config,
+        submit_accepted_stake, wait_for_inclusion,
     },
 };
 use crate::cucumber::{
     error::{StepError, StepResult},
-    stake_scenario::StakeScenario,
+    stake_scenario::{StakeScenario, simple_balance_transfer_instruction, transfer_instruction},
     world::CucumberWorld,
 };
 
@@ -153,5 +154,77 @@ async fn stake_second_sequencer_key(world: &mut CucumberWorld, step: &Step) -> S
 fn off_curve_key_bytes(world: &mut CucumberWorld, step: &Step) -> StepResult {
     log_step(step);
     world.stake_mut()?.set_off_curve_bytes(OFF_CURVE_BYTES);
+    Ok(())
+}
+
+#[given("the stake_chain_caller test program is deployed")]
+async fn deploy_stake_chain_caller(world: &mut CucumberWorld, step: &Step) -> StepResult {
+    log_step(step);
+    deploy_and_wait(world.lez()?, &test_programs::stake_chain_caller()).await
+}
+
+#[given("the simple_balance_transfer test program is deployed")]
+async fn deploy_simple_balance_transfer(world: &mut CucumberWorld, step: &Step) -> StepResult {
+    log_step(step);
+    deploy_and_wait(world.lez()?, &test_programs::simple_balance_transfer()).await
+}
+
+#[given(expr = "a funding account owned by the simple_balance_transfer program holding {string}")]
+async fn fund_account_owned_by_simple_mover(
+    world: &mut CucumberWorld,
+    step: &Step,
+    expression: String,
+) -> StepResult {
+    log_step(step);
+    let balance = world.stake()?.amount(&expression)?;
+    let context = world.lez()?;
+    let simple_mover_id = test_programs::simple_balance_transfer().id();
+
+    // A fresh default account the scenario wallet can sign for.
+    let funding_id = context.new_public_account().await?;
+
+    // Claim it under simple_balance_transfer: its one-account branch claims a
+    // signed default account and ignores the instruction value.
+    let claim_hash = context
+        .send_program_transaction(
+            vec![AccountIdentity::Public(funding_id)],
+            simple_balance_transfer_instruction(0)?,
+            simple_mover_id,
+        )
+        .await?;
+    wait_for_inclusion(context, claim_hash).await?;
+    let owner = get_account(context, funding_id).await?.program_owner;
+    if owner != simple_mover_id.into() {
+        return Err(StepError::AssertionFailed {
+            message: format!(
+                "the funding account is owned by {owner}, expected simple_balance_transfer"
+            ),
+        });
+    }
+
+    // Credit it from a genesis account. The account is already claimed, so the
+    // authenticated_transfer only moves balance and does not re-claim it —
+    // ownership stays with simple_balance_transfer, which is what lets it debit
+    // the account as the Stake mover.
+    let supply_id = first_configured_public_account(context).await?;
+    let fund_hash = context
+        .send_program_transaction(
+            vec![
+                AccountIdentity::Public(supply_id),
+                AccountIdentity::PublicNoSign(funding_id),
+            ],
+            transfer_instruction(balance)?,
+            programs::authenticated_transfer().id(),
+        )
+        .await?;
+    wait_for_inclusion(context, fund_hash).await?;
+    let funded = get_account(context, funding_id).await?.balance;
+    if funded != balance {
+        return Err(StepError::AssertionFailed {
+            message: format!("the funding account holds {funded}, expected {balance}"),
+        });
+    }
+
+    world.stake_mut()?.set_funding_id(funding_id);
     Ok(())
 }

--- a/integration_tests/src/testing_framework/apps/wallet.rs
+++ b/integration_tests/src/testing_framework/apps/wallet.rs
@@ -103,6 +103,10 @@ enum WalletRequest {
         program_id: ProgramId,
         response: oneshot::Sender<Result<HashType, String>>,
     },
+    SendProgramDeployment {
+        bytecode: Vec<u8>,
+        response: oneshot::Sender<Result<HashType, String>>,
+    },
     WalletPassword {
         response: oneshot::Sender<Result<String, String>>,
     },
@@ -393,6 +397,14 @@ impl WalletActor {
                                     .map_err(|error| format!("{error:?}"));
                                 let _unused = response.send(result);
                             }
+                            WalletRequest::SendProgramDeployment { bytecode, response } => {
+                                let result = components
+                                    .wallet
+                                    .send_program_deployment_transaction(bytecode)
+                                    .await
+                                    .map_err(|error| format!("{error:?}"));
+                                let _unused = response.send(result);
+                            }
                             WalletRequest::WalletPassword { response } => {
                                 let _unused = response.send(Ok(components.password.clone()));
                             }
@@ -605,6 +617,16 @@ impl LezRuntime {
             response,
         })
         .await
+    }
+
+    /// Deploys a program at runtime by submitting its bytecode as a program
+    /// deployment transaction; returns the submission hash.
+    pub async fn send_program_deployment_transaction(
+        &self,
+        bytecode: Vec<u8>,
+    ) -> Result<HashType, DynError> {
+        self.request(|response| WalletRequest::SendProgramDeployment { bytecode, response })
+            .await
     }
 
     /// Executes an authenticated public transfer using wallet-resolved labels.

--- a/test_programs/guest/src/bin/stake_chain_caller.rs
+++ b/test_programs/guest/src/bin/stake_chain_caller.rs
@@ -1,0 +1,50 @@
+use lee_core::program::{
+    AccountPostState, ChainedCall, InstructionData, ProgramId, ProgramInput, ProgramOutput,
+    read_lee_inputs,
+};
+
+/// A program whose only job is to originate a chained call: it forwards a
+/// caller-supplied instruction to a caller-supplied program, passing its own
+/// input accounts straight through. Used to reach the `caller_program_id`
+/// guards in programs that reject being invoked as a chained call — e.g.
+/// `sequencer_stake`'s `Stake` (top-level only) and `ConfirmStake`
+/// (self-chained only).
+type Instruction = (ProgramId, InstructionData);
+
+fn main() {
+    let (
+        ProgramInput {
+            self_program_id,
+            caller_program_id,
+            pre_states,
+            instruction: (target_program_id, forwarded_instruction_data),
+        },
+        instruction_words,
+    ) = read_lee_inputs::<Instruction>();
+
+    // Leave every input account untouched; this program exists only to be the
+    // caller of `target_program_id`, never to mutate state itself.
+    let post_states = pre_states
+        .iter()
+        .map(|pre| AccountPostState::new(pre.account.clone()))
+        .collect::<Vec<_>>();
+
+    // Forward the same pre-states into the chained call. The callee sees this
+    // program as its `caller_program_id`.
+    let chained_call = ChainedCall {
+        program_id: target_program_id,
+        pre_states: pre_states.clone(),
+        instruction_data: forwarded_instruction_data,
+        pda_seeds: Vec::new(),
+    };
+
+    ProgramOutput::new(
+        self_program_id,
+        caller_program_id,
+        instruction_words,
+        pre_states,
+        post_states,
+    )
+    .with_chained_calls(vec![chained_call])
+    .write();
+}

--- a/test_programs/src/lib.rs
+++ b/test_programs/src/lib.rs
@@ -38,6 +38,16 @@ pub const fn chain_caller() -> Program {
 
 #[must_use]
 #[inline]
+pub const fn stake_chain_caller() -> Program {
+    use guests::{STAKE_CHAIN_CALLER_ELF, STAKE_CHAIN_CALLER_ID, STAKE_CHAIN_CALLER_PATH};
+
+    let _unused = STAKE_CHAIN_CALLER_PATH;
+
+    Program::new_unchecked(STAKE_CHAIN_CALLER_ID, Cow::Borrowed(STAKE_CHAIN_CALLER_ELF))
+}
+
+#[must_use]
+#[inline]
 pub const fn authority_proxy() -> Program {
     use guests::{AUTHORITY_PROXY_ELF, AUTHORITY_PROXY_ID, AUTHORITY_PROXY_PATH};
 


### PR DESCRIPTION
## 🎯 Purpose

Add chained-caller and second-mover test prerequisites to continue with cucumber sequencer integration tests.

## ⚙️ Tests added

### `stake_account_validation.feature` — `@stake_accounts_ci`

- **P-21** — Registration through a second mover program is accepted

### `stake_instruction_validation.feature` — `@stake_instruction_ci`

- **P-17** — Stake invoked as a chained call is rejected

## 🧪 How to Test

```sh
cargo test -p integration_tests --features cucumber --test cucumber -- --tags '@P-17'
cargo test -p integration_tests --features cucumber --test cucumber -- --tags '@P-21'
```

## 🔜 Future Work

To add remaining tests planned for sequencer registration these prerequisites need to be developed first:
  - Finish cucumber sequencer integration tests to cover spec completely.

Related tests will be added in upcoming PRs.

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments


