### PR TITLE
refactor(sequencer): thread the finalized L1 slot through FollowUpdate

### DIFF
--- a/lez/chain_state/src/chain.rs
+++ b/lez/chain_state/src/chain.rs
@@ -164,8 +164,8 @@ impl ChainState {
     /// Drops our record of every block this update reports on. The sdk omits our
     /// own landed block from `adopted` except on a branch change, so `finalized`
     /// carries the ordinary case.
-    fn resolve_own_publishes(&mut self, reports: [&[Block]; 3]) {
-        for block in reports.into_iter().flatten() {
+    fn resolve_own_publishes<'block>(&mut self, reports: impl IntoIterator<Item = &'block Block>) {
+        for block in reports {
             self.own_publishes.remove(&block.header.hash);
         }
     }
@@ -323,17 +323,21 @@ impl ChainState {
         &mut self,
         orphaned: &[Block],
         adopted: &[Block],
-        finalized: &[Block],
-        finalized_slot: Slot,
+        finalized: &[(Block, Slot)],
         channel_tip: MsgId,
     ) -> FollowOutcome {
         // Before the tip is judged, so this update's news frees its own parents.
-        self.resolve_own_publishes([orphaned, adopted, finalized]);
+        self.resolve_own_publishes(
+            orphaned
+                .iter()
+                .chain(adopted)
+                .chain(finalized.iter().map(|(block, _)| block)),
+        );
 
         let adopted_outcomes = self.apply_channel_update(orphaned, adopted);
         let finalized_outcomes = finalized
             .iter()
-            .map(|block| self.apply_finalized(block, finalized_slot))
+            .map(|(block, l1_slot)| self.apply_finalized(block, *l1_slot))
             .collect();
 
         let cursor_moved = self.cursor_may_move_to(channel_tip);
@@ -938,13 +942,13 @@ mod tests {
         // Nothing published yet: root is the parent the first inscription needs.
         assert!(
             chain
-                .apply_follow(&[], &[], &[], Slot::from(0), MsgId::root())
+                .apply_follow(&[], &[], &[], MsgId::root())
                 .cursor_moved
         );
 
         chain.record_own_inscription(msg(1), genesis.header.hash);
 
-        let outcome = chain.apply_follow(&[], &[], &[], Slot::from(0), MsgId::root());
+        let outcome = chain.apply_follow(&[], &[], &[], MsgId::root());
         assert!(!outcome.cursor_moved);
         assert_eq!(
             chain.pin_parent(),
@@ -959,7 +963,7 @@ mod tests {
     fn a_tip_naming_an_entry_we_already_chained_on_is_refused() {
         let (mut chain, _ours) = chain_with_our_block(msg(2), msg(3));
 
-        let outcome = chain.apply_follow(&[], &[], &[], Slot::from(0), msg(2));
+        let outcome = chain.apply_follow(&[], &[], &[], msg(2));
 
         assert!(!outcome.cursor_moved);
         assert_eq!(
@@ -975,7 +979,7 @@ mod tests {
     fn a_tip_elsewhere_is_taken_even_when_no_block_of_ours_is_named() {
         let (mut chain, _ours) = chain_with_our_block(msg(2), msg(3));
 
-        let outcome = chain.apply_follow(&[], &[], &[], Slot::from(0), msg(9));
+        let outcome = chain.apply_follow(&[], &[], &[], msg(9));
 
         assert!(outcome.cursor_moved);
         assert_eq!(chain.pin_parent(), Some(msg(9)));
@@ -990,11 +994,16 @@ mod tests {
             let (orphaned, adopted, finalized) = match report {
                 "adopted" => (Vec::new(), held, Vec::new()),
                 "orphaned" => (held, Vec::new(), Vec::new()),
-                _ => (Vec::new(), Vec::new(), held),
+                _ => (
+                    Vec::new(),
+                    Vec::new(),
+                    held.into_iter()
+                        .map(|block| (block, Slot::from(0)))
+                        .collect(),
+                ),
             };
 
-            let outcome =
-                chain.apply_follow(&orphaned, &adopted, &finalized, Slot::from(0), msg(2));
+            let outcome = chain.apply_follow(&orphaned, &adopted, &finalized, msg(2));
 
             assert!(
                 outcome.cursor_moved,
@@ -1010,7 +1019,7 @@ mod tests {
         let (mut chain, ours) = chain_with_our_block(msg(2), msg(3));
         assert!(chain.pin_is_ours());
 
-        chain.apply_follow(&[], &[], &[ours], Slot::from(0), msg(3));
+        chain.apply_follow(&[], &[], &[(ours, Slot::from(0))], msg(3));
 
         assert_eq!(chain.pin_parent(), Some(msg(3)));
         assert!(

--- a/lez/chain_state/src/chain.rs
+++ b/lez/chain_state/src/chain.rs
@@ -642,14 +642,17 @@ mod tests {
         let genesis = produce_dummy_block(1, None, vec![]);
         chain.apply_finalized(&genesis, slot(10));
 
-        // Skip-ahead finalized block, not in head: parks the final tier.
+        // Skip-ahead finalized block, not in head: parks the final tier. Through
+        // `apply_follow`, so the stall records the slot threaded per block.
         let bad = produce_dummy_block(3, Some(genesis.header.hash), vec![]);
+        let outcome = chain.apply_follow(&[], &[], &[(bad, slot(20))], msg(1));
         assert!(matches!(
-            chain.apply_finalized(&bad, slot(20)),
-            AcceptOutcome::Parked(_)
+            outcome.finalized.as_slice(),
+            [AcceptOutcome::Parked(_)]
         ));
         let stall = chain.final_stall().expect("final stall recorded");
         assert_eq!(stall.block_id, Some(3));
+        assert_eq!(stall.l1_slot, slot(20));
     }
 
     #[test]

--- a/lez/sequencer/core/src/block_publisher.rs
+++ b/lez/sequencer/core/src/block_publisher.rs
@@ -71,9 +71,9 @@ pub struct FollowUpdate {
     /// Blocks dropped from the branch by an L1 reorg: reverted from the
     /// `head`, their user txs resubmitted to the mempool.
     pub orphaned: Vec<Block>,
-    /// Blocks whose containing L1 block reached finality: they move into the
-    /// irreversible `final` tier.
-    pub finalized: Vec<Block>,
+    /// Blocks whose containing L1 block reached finality, each with that L1
+    /// block's slot: they move into the irreversible `final` tier.
+    pub finalized: Vec<(Block, Slot)>,
     /// Finalized Bedrock deposit events, to record and mint on L2.
     pub deposits: Vec<DepositInfo>,
     /// Finalized Bedrock withdraw events, to reconcile against local intents.
@@ -447,14 +447,19 @@ impl BlockPublisherTrait for ZoneSdkPublisher {
                                     let mut deposits = Vec::new();
                                     let mut withdrawals = Vec::new();
                                     let mut undecodable = Vec::new();
-                                    for op in finalized
+                                    for (l1_slot, op) in finalized
                                         .into_iter()
-                                        .flat_map(|item| item.ops.into_iter())
+                                        .flat_map(|item| {
+                                            let l1_slot = item.l1_slot;
+                                            item.ops.into_iter().map(move |op| (l1_slot, op))
+                                        })
                                     {
                                         match op {
                                             FinalizedOp::Inscription(inscription) => {
                                                 match block_from_inscription(&inscription) {
-                                                    Some(block) => finalized_blocks.push(block),
+                                                    Some(block) => {
+                                                        finalized_blocks.push((block, l1_slot));
+                                                    }
                                                     // An empty payload is not a
                                                     // block, but we don't slash
                                                     // for it.

--- a/lez/sequencer/core/src/lib.rs
+++ b/lez/sequencer/core/src/lib.rs
@@ -1707,18 +1707,7 @@ async fn apply_follow_update<S: StorageActorTrait>(
             adopted: outcomes,
             finalized: finalized_outcomes,
             cursor_moved: _,
-        } = chain.apply_follow(
-            &orphaned,
-            &adopted,
-            &finalized,
-            // FIXME: thread the finalized inscription's L1 slot instead of
-            // `Slot::from(0)`; only used for the invalid-finalized stall.
-            // logos-blockchain PR #3147 surfaces it as `FinalizedTx.l1_slot` —
-            // wire it through `FollowUpdate::finalized` once the zone-sdk pin is
-            // bumped past that (a separate PR).
-            Slot::from(0),
-            checkpoint.last_msg_id,
-        );
+        } = chain.apply_follow(&orphaned, &adopted, &finalized, checkpoint.last_msg_id);
 
         // An adoption that does not apply freezes the head where it is, and
         // every later one then fails the same way. Nothing else reports it.
@@ -1750,7 +1739,7 @@ async fn apply_follow_update<S: StorageActorTrait>(
         // or dropping its deposit records would lose them for good.
         let mut irreversible: Vec<&Block> = Vec::new();
         let mut final_advanced = false;
-        for (block, outcome) in finalized.iter().zip(&finalized_outcomes) {
+        for ((block, _), outcome) in finalized.iter().zip(&finalized_outcomes) {
             match outcome {
                 AcceptOutcome::Applied => {
                     to_persist.push((block, true));

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -922,7 +922,7 @@ async fn a_redelivered_record_is_dropped_once_its_delivery_is_irreversible() {
         &mempool_handle,
         FollowUpdate {
             checkpoint: checkpoint_at(mock_msg_of(&delivery_block)),
-            finalized: vec![delivery_block],
+            finalized: vec![(delivery_block, Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -1318,7 +1318,7 @@ async fn a_stake_only_moves_the_committee_once_it_has_finalized() {
         &sequencer.chain(),
         &mempool_handle,
         FollowUpdate {
-            finalized: vec![genesis],
+            finalized: vec![(genesis, Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -2629,7 +2629,7 @@ async fn the_pin_stays_on_a_finalized_entry_through_its_pruning_report() {
         &mempool_handle,
         FollowUpdate {
             checkpoint: checkpoint_at(block2_msg),
-            finalized: vec![block2.clone()],
+            finalized: vec![(block2.clone(), Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -2818,7 +2818,7 @@ async fn a_readopted_block_above_the_head_keeps_the_published_height() {
         &sequencer.chain(),
         &mempool_handle,
         FollowUpdate {
-            finalized: vec![produced[0].clone()],
+            finalized: vec![(produced[0].clone(), Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -3065,7 +3065,7 @@ async fn follow_orphan_of_a_finalized_block_requeues_nothing() {
         &sequencer.chain(),
         &mempool_handle,
         FollowUpdate {
-            finalized: vec![block2.clone()],
+            finalized: vec![(block2.clone(), Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -3119,7 +3119,7 @@ async fn follow_finalized_own_block_moves_final_tier_and_marks_store() {
         FollowUpdate {
             adopted: vec![],
             orphaned: vec![],
-            finalized: vec![block2],
+            finalized: vec![(block2, Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -3175,7 +3175,7 @@ async fn follow_finalized_delivery_drops_its_pending_record() {
         &sequencer.chain(),
         &mempool_handle,
         FollowUpdate {
-            finalized: vec![delivery_block],
+            finalized: vec![(delivery_block, Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -3224,7 +3224,7 @@ async fn a_parked_finalized_block_does_not_drop_a_dispatch_record() {
         &sequencer.chain(),
         &mempool_handle,
         FollowUpdate {
-            finalized: vec![parked],
+            finalized: vec![(parked, Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -3263,7 +3263,7 @@ async fn follow_finalized_backfill_block_is_applied_and_marked_finalized() {
         FollowUpdate {
             adopted: vec![],
             orphaned: vec![],
-            finalized: vec![peer_block.clone()],
+            finalized: vec![(peer_block.clone(), Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -3329,7 +3329,7 @@ async fn parked_finalized_block_neither_sweeps_the_store_nor_drops_its_deposit_r
         FollowUpdate {
             adopted: vec![],
             orphaned: vec![],
-            finalized: vec![parked],
+            finalized: vec![(parked, Slot::from(0))],
             ..empty_follow_update()
         },
     )
@@ -3513,7 +3513,7 @@ async fn restart_reanchors_on_the_persisted_final_snapshot() {
             FollowUpdate {
                 adopted: vec![],
                 orphaned: vec![],
-                finalized: vec![block2],
+                finalized: vec![(block2, Slot::from(0))],
                 ..empty_follow_update()
             },
         )
@@ -3625,7 +3625,7 @@ async fn follow_update_persists_blocks_meta_and_state_atomically() {
         FollowUpdate {
             adopted: vec![block2.clone(), block3.clone()],
             orphaned: vec![],
-            finalized: vec![block2],
+            finalized: vec![(block2, Slot::from(0))],
             ..empty_follow_update()
         },
     )

--- a/lez/sequencer/core/src/tests/reconstruction.rs
+++ b/lez/sequencer/core/src/tests/reconstruction.rs
@@ -362,10 +362,10 @@ async fn reconstruction_ignores_a_duplicate_height_the_final_tier_settled() {
 
     // Sequencer B: the cold-start backfill finalizes A's chain into its store.
     let (seq_b, mempool_b) = start_sequencer(setup_sequencer_config()).await;
-    let mut finalized: Vec<Block> = Vec::new();
+    let mut finalized: Vec<(Block, Slot)> = Vec::new();
     for id in seq_b.block_store().genesis_id()..=tip_a.id {
         let block = seq_a.block_store().block_at_id(id).await.unwrap().unwrap();
-        finalized.push(block);
+        finalized.push((block, Slot::from(0)));
     }
     apply_follow_update(
         seq_b.block_store().storage_ref(),


### PR DESCRIPTION
## 🎯 Purpose

Resolves the FIXME in `sequencer_core::apply_follow_update`: the invalid-finalized stall was recorded with a placeholder `Slot::from(0)` because the zone-sdk did not surface the L1 slot of a finalized inscription. I had added it on https://github.com/logos-blockchain/logos-blockchain/pull/3147 via `FinalizedTx.l1_slot`, and our latest pin now includes it. This PR simply wires it through, so `StallReason` carries the real L1 slot of the block that failed to apply.

## ⚙️ Approach

The slot is per-`FinalizedTx`, not per-update (one `BlocksProcessed` event can carry finalized txs from different L1 blocks), so it rides alongside each block instead of being a single `apply_follow` argument.

- [x] Change `FollowUpdate::finalized` from `Vec<Block>` to `Vec<(Block, Slot)>`, stamping each decoded block with its `FinalizedTx.l1_slot` in the publisher event loop
- [x] Change `ChainState::apply_follow` to take `&[(Block, Slot)]` and drop the blanket `finalized_slot` parameter; each block feeds its own slot into `apply_finalized`
- [x] Change `resolve_own_publishes` to take an `impl IntoIterator<Item = &Block>` (the finalized report is no longer a plain block slice)
- [x] Fix the follow-path call site: FIXME comment and `Slot::from(0)` deleted

## 🧪 How to Test

No behavior change outside the stall's recorded slot; existing coverage exercises the threading (`invalid_finalized_block_sets_final_stall` and the follow-update suite):

```sh
RISC0_DEV_MODE=1 cargo nextest run -p chain_state -p sequencer_core --all-features
```

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] ~Add/update tests~ existing tests were wired
- [x] Add/update documentation and inline comments