### PR TITLE
feat: fees ffi fixes

### DIFF
--- a/integration_tests/tests/wallet_ffi.rs
+++ b/integration_tests/tests/wallet_ffi.rs
@@ -200,12 +200,6 @@ unsafe extern "C" {
         out_result: *mut FfiTransferResult,
     ) -> error::WalletFfiError;
 
-    fn wallet_ffi_register_public_account(
-        handle: *mut WalletHandle,
-        account_id: *const FfiBytes32,
-        out_result: *mut FfiTransferResult,
-    ) -> error::WalletFfiError;
-
     fn wallet_ffi_register_private_account(
         handle: *mut WalletHandle,
         account_id: *const FfiBytes32,
@@ -839,7 +833,7 @@ fn wallet_ffi_base58_to_account_id() -> Result<()> {
 }
 
 #[test]
-fn wallet_ffi_registering_an_unfunded_public_account_is_refused() -> Result<()> {
+fn wallet_ffi_public_account_is_claimed_by_funded_transfer() -> Result<()> {
     let ctx = BlockingTestContext::new_default()?;
     let home = tempfile::tempdir()?;
     let FfiCreateWalletOutput {
@@ -866,24 +860,27 @@ fn wallet_ffi_registering_an_unfunded_public_account_is_refused() -> Result<()> 
     };
     assert_eq!(account.program_owner, DEFAULT_PROGRAM_OWNER);
 
-    // A bare Initialize is a charged transaction whose only account — and thus
-    // fee payer — is the fresh, unfunded one, so admission must refuse it: a
-    // public account is claimed by its first funded transfer instead.
-    let mut transfer_result = FfiTransferResult::default();
-    let result = unsafe {
-        wallet_ffi_register_public_account(
+    // A bare Initialize is inadmissible under fees (its only signer would be
+    // the unfunded fresh account), so a funded transfer from an owned account
+    // is the registration path: it signs with the fresh account's key too,
+    // claiming it.
+    let from: FfiBytes32 = ctx.ctx().existing_public_accounts()[0].into();
+    let amount: [u8; 16] = 100_u128.to_le_bytes();
+    let mut claim_result = FfiTransferResult::default();
+    unsafe {
+        wallet_ffi_transfer_public(
             wallet_ffi_handle,
+            &raw const from,
             &raw const out_account_id,
-            &raw mut transfer_result,
+            &raw const amount,
+            &raw mut claim_result,
         )
-    };
-    assert!(
-        !matches!(result, error::WalletFfiError::Success),
-        "registering an unfunded public account must be refused at fee admission"
-    );
-    assert!(!transfer_result.success);
+        .unwrap();
+    }
 
-    // Nothing landed: the account stays unclaimed.
+    log::info!("Waiting for next block creation");
+    std::thread::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS));
+
     let account: Account = unsafe {
         let mut out_account = FfiAccount::default();
         wallet_ffi_get_account_public(
@@ -894,10 +891,14 @@ fn wallet_ffi_registering_an_unfunded_public_account_is_refused() -> Result<()> 
         .unwrap();
         (&out_account).try_into().unwrap()
     };
-    assert_eq!(account.program_owner, DEFAULT_PROGRAM_OWNER);
+    assert_eq!(
+        account.program_owner,
+        programs::authenticated_transfer().id().into()
+    );
+    assert_eq!(ffi_balance(wallet_ffi_handle, &out_account_id, true), 100);
 
     unsafe {
-        wallet_ffi_free_transfer_result(&raw mut transfer_result);
+        wallet_ffi_free_transfer_result(&raw mut claim_result);
         wallet_ffi_destroy(wallet_ffi_handle);
     }
 

--- a/lez/indexer/ffi/indexer_ffi.h
+++ b/lez/indexer/ffi/indexer_ffi.h
@@ -176,11 +176,25 @@ typedef struct FfiVec_u8 {
 
 typedef struct FfiVec_u8 FfiInstructionDataList;
 
+/**
+ * Fee declaration of a public transaction. Held inline (not behind a
+ * pointer): a fee-exempt transaction carries `has_fee == false` and a zeroed
+ * declaration.
+ */
+typedef struct FfiFeeDeclaration {
+  FfiAccountId payer;
+  uint64_t gas_limit;
+  uint64_t tip;
+  struct FfiU128 max_fee;
+} FfiFeeDeclaration;
+
 typedef struct FfiPublicMessage {
   struct FfiProgramId program_id;
   FfiAccountIdList account_ids;
   FfiNonceList nonces;
   FfiInstructionDataList instruction_data;
+  bool has_fee;
+  struct FfiFeeDeclaration fee;
 } FfiPublicMessage;
 
 typedef struct FfiSignaturePubKeyEntry {

--- a/lez/indexer/ffi/src/api/types/transaction.rs
+++ b/lez/indexer/ffi/src/api/types/transaction.rs
@@ -8,7 +8,7 @@ use indexer_service_protocol::{
 
 use crate::api::types::{
     FfiAccountId, FfiBytes32, FfiHashType, FfiOption, FfiProgramId, FfiPublicKey, FfiSignature,
-    FfiVec,
+    FfiU128, FfiVec,
     account::FfiAccount,
     vectors::{
         FfiAccountIdList, FfiInstructionDataList, FfiNonceList, FfiPrivateActionList,
@@ -582,42 +582,6 @@ pub unsafe extern "C" fn free_ffi_transaction_vec(val: *mut FfiVec<FfiTransactio
     free_transaction_vec_value(*boxed);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn public_transaction_fee_roundtrips_over_the_ffi() {
-        let tx = |fee| PublicTransaction {
-            hash: HashType([1; 32]),
-            message: PublicMessage {
-                program_id: ProgramId([2; 8]),
-                account_ids: vec![AccountId { value: [3; 32] }],
-                nonces: vec![],
-                instruction_data: vec![9, 9],
-                fee,
-            },
-            witness_set: WitnessSet {
-                signatures_and_public_keys: vec![],
-                proof: None,
-            },
-        };
-
-        let fee = FeeDeclaration {
-            payer: AccountId { value: [3; 32] },
-            gas_limit: 5,
-            tip: 1,
-            max_fee: 42,
-        };
-        for fee in [None, Some(fee)] {
-            let original = tx(fee);
-            let ffi: FfiPublicTransactionBody = original.clone().into();
-            let back: PublicTransaction = Box::new(ffi).into();
-            assert_eq!(back.message.fee, original.message.fee);
-        }
-    }
-}
-
 fn cast_validity_window(window: ValidityWindow) -> [u64; 2] {
     [
         window.0.0.unwrap_or_default(),
@@ -639,4 +603,42 @@ const fn cast_ffi_validity_window(ffi_window: [u64; 2]) -> ValidityWindow {
     };
 
     ValidityWindow((left, right))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_transaction_fee_roundtrips_over_the_ffi() {
+        let tx = |fee| PublicTransaction {
+            hash: HashType([1; 32]),
+            message: PublicMessage {
+                program_id: ProgramId([2; 8]),
+                account_ids: vec![AccountId { value: [3; 32] }],
+                nonces: vec![],
+                instruction_data: vec![9, 9],
+                fee,
+            },
+            witness_set: WitnessSet {
+                signatures_and_public_keys: vec![],
+                proof: None,
+            },
+        };
+
+        for fee in [
+            None,
+            Some(FeeDeclaration {
+                payer: AccountId { value: [3; 32] },
+                gas_limit: 5,
+                tip: 1,
+                max_fee: 42,
+            }),
+        ] {
+            let original = tx(fee);
+            let ffi: FfiPublicTransactionBody = original.clone().into();
+            let back: PublicTransaction = Box::new(ffi).into();
+            assert_eq!(back.message.fee, original.message.fee);
+        }
+    }
 }

--- a/lez/indexer/ffi/src/api/types/transaction.rs
+++ b/lez/indexer/ffi/src/api/types/transaction.rs
@@ -1,6 +1,6 @@
 use indexer_service_protocol::{
     AccountId, Ciphertext, Commitment, CommitmentSetDigest, EncryptedAccountData,
-    EphemeralPublicKey, HashType, Nullifier, PrivacyPreservingMessage,
+    EphemeralPublicKey, FeeDeclaration, HashType, Nullifier, PrivacyPreservingMessage,
     PrivacyPreservingTransaction, PrivateAction, ProgramDeploymentMessage,
     ProgramDeploymentTransaction, ProgramId, Proof, PublicActionWithID, PublicKey, PublicMessage,
     PublicTransaction, Signature, Transaction, ValidityWindow, WitnessSet,
@@ -65,9 +65,7 @@ impl From<Box<FfiPublicTransactionBody>> for PublicTransaction {
                     std_vec.into_iter().map(Into::into).collect()
                 },
                 instruction_data: value.message.instruction_data.into(),
-                // FIXME: The FFI surface does not carry the fee yet; reconstruct
-                // it as `None` (the exempt/system value).
-                fee: None,
+                fee: value.message.has_fee.then(|| value.message.fee.into()),
             },
             witness_set: WitnessSet {
                 signatures_and_public_keys: {
@@ -88,12 +86,57 @@ impl From<Box<FfiPublicTransactionBody>> for PublicTransaction {
     }
 }
 
+/// Fee declaration of a public transaction. Held inline (not behind a
+/// pointer): a fee-exempt transaction carries `has_fee == false` and a zeroed
+/// declaration.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FfiFeeDeclaration {
+    pub payer: FfiAccountId,
+    pub gas_limit: u64,
+    pub tip: u64,
+    pub max_fee: FfiU128,
+}
+
+impl From<FeeDeclaration> for FfiFeeDeclaration {
+    fn from(value: FeeDeclaration) -> Self {
+        let FeeDeclaration {
+            payer,
+            gas_limit,
+            tip,
+            max_fee,
+        } = value;
+
+        Self {
+            payer: payer.into(),
+            gas_limit,
+            tip,
+            max_fee: max_fee.into(),
+        }
+    }
+}
+
+impl From<FfiFeeDeclaration> for FeeDeclaration {
+    fn from(value: FfiFeeDeclaration) -> Self {
+        Self {
+            payer: AccountId {
+                value: value.payer.data,
+            },
+            gas_limit: value.gas_limit,
+            tip: value.tip,
+            max_fee: value.max_fee.into(),
+        }
+    }
+}
+
 #[repr(C)]
 pub struct FfiPublicMessage {
     pub program_id: FfiProgramId,
     pub account_ids: FfiAccountIdList,
     pub nonces: FfiNonceList,
     pub instruction_data: FfiInstructionDataList,
+    pub has_fee: bool,
+    pub fee: FfiFeeDeclaration,
 }
 
 impl From<PublicMessage> for FfiPublicMessage {
@@ -103,8 +146,7 @@ impl From<PublicMessage> for FfiPublicMessage {
             account_ids,
             nonces,
             instruction_data,
-            // FIXME: The fee is not carried over the FFI yet.
-            fee: _,
+            fee,
         } = value;
 
         Self {
@@ -120,6 +162,8 @@ impl From<PublicMessage> for FfiPublicMessage {
                 .collect::<Vec<_>>()
                 .into(),
             instruction_data: instruction_data.into(),
+            has_fee: fee.is_some(),
+            fee: fee.map(Into::into).unwrap_or_default(),
         }
     }
 }
@@ -536,6 +580,42 @@ pub unsafe extern "C" fn free_ffi_transaction_vec(val: *mut FfiVec<FfiTransactio
     // Reclaim the outer box, then the backing buffer and each transaction.
     let boxed = unsafe { Box::from_raw(val) };
     free_transaction_vec_value(*boxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_transaction_fee_roundtrips_over_the_ffi() {
+        let tx = |fee| PublicTransaction {
+            hash: HashType([1; 32]),
+            message: PublicMessage {
+                program_id: ProgramId([2; 8]),
+                account_ids: vec![AccountId { value: [3; 32] }],
+                nonces: vec![],
+                instruction_data: vec![9, 9],
+                fee,
+            },
+            witness_set: WitnessSet {
+                signatures_and_public_keys: vec![],
+                proof: None,
+            },
+        };
+
+        let fee = FeeDeclaration {
+            payer: AccountId { value: [3; 32] },
+            gas_limit: 5,
+            tip: 1,
+            max_fee: 42,
+        };
+        for fee in [None, Some(fee)] {
+            let original = tx(fee);
+            let ffi: FfiPublicTransactionBody = original.clone().into();
+            let back: PublicTransaction = Box::new(ffi).into();
+            assert_eq!(back.message.fee, original.message.fee);
+        }
+    }
 }
 
 fn cast_validity_window(window: ValidityWindow) -> [u64; 2] {

--- a/lez/sequencer/service/rpc/src/lib.rs
+++ b/lez/sequencer/service/rpc/src/lib.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 
 use jsonrpsee::proc_macros::rpc;
-#[cfg(feature = "server")]
-use jsonrpsee::types::ErrorObjectOwned;
+pub use jsonrpsee::types::ErrorObjectOwned;
 #[cfg(feature = "client")]
 pub use jsonrpsee::{core::ClientError, http_client::HttpClientBuilder as SequencerClientBuilder};
+pub use sequencer_service_protocol::AdmissionRejection;
 use sequencer_service_protocol::{
     Account, AccountId, Block, BlockId, ChannelId, Commitment, CommitmentSetDigest,
     CrossZoneDeadLetterReport, CrossZoneDeadLetterRequeue, FeeStateQuote, HashType, LeeTransaction,

--- a/lez/wallet-ffi/src/error.rs
+++ b/lez/wallet-ffi/src/error.rs
@@ -45,6 +45,8 @@ pub enum WalletFfiError {
     InvalidKeyValue = 16,
     /// Invalid program bytecode.
     InvalidBytecode = 17,
+    /// Fee payer cannot fund the fee reserve.
+    PayerCannotFund = 18,
     /// Internal error (catch-all).
     InternalError = 99,
 }

--- a/lez/wallet-ffi/src/lib.rs
+++ b/lez/wallet-ffi/src/lib.rs
@@ -90,6 +90,10 @@ pub(crate) fn block_on<F: std::future::Future>(future: F) -> F::Output {
     reason = "We want to catch all errors for future proofing"
 )]
 pub(crate) fn map_execution_error(e: ExecutionFailureKind) -> FfiError {
+    if let Some(::wallet::AdmissionRejection::PayerCannotFund { .. }) = e.fee_admission_rejection()
+    {
+        return FfiError::PayerCannotFund;
+    }
     match e {
         ExecutionFailureKind::InsufficientFundsError => FfiError::InsufficientFunds,
         ExecutionFailureKind::KeyNotFoundError => FfiError::KeyNotFound,

--- a/lez/wallet-ffi/src/transfer.rs
+++ b/lez/wallet-ffi/src/transfer.rs
@@ -32,6 +32,9 @@ fn optional_c_str(ptr: *const c_char) -> Option<String> {
 ///
 /// Transfers tokens from one public account to another on the network.
 ///
+/// If `to` is a fresh, unclaimed account whose key this wallet holds, the
+/// transfer also signs with that key and claims the account.
+///
 /// # Parameters
 /// - `handle`: Valid wallet handle
 /// - `from`: Source account ID (must be owned by this wallet)
@@ -571,77 +574,6 @@ pub unsafe extern "C" fn wallet_ffi_transfer_private_owned(
     }
 }
 
-/// Register a public account on the network.
-///
-/// This initializes a public account on the blockchain. The account must be
-/// owned by this wallet.
-///
-/// # Parameters
-/// - `handle`: Valid wallet handle
-/// - `account_id`: Account ID to register
-/// - `out_result`: Output pointer for registration result
-///
-/// # Returns
-/// - `Success` if the registration was submitted successfully
-/// - Error code on failure
-///
-/// # Memory
-/// The result must be freed with `wallet_ffi_free_transfer_result()`.
-///
-/// # Safety
-/// - `handle` must be a valid wallet handle from `wallet_ffi_create_new` or `wallet_ffi_open`
-/// - `account_id` must be a valid pointer to a `FfiBytes32` struct
-/// - `out_result` must be a valid pointer to a `FfiTransferResult` struct
-#[no_mangle]
-pub unsafe extern "C" fn wallet_ffi_register_public_account(
-    handle: *mut WalletHandle,
-    account_id: *const FfiBytes32,
-    out_result: *mut FfiTransferResult,
-) -> WalletFfiError {
-    let wrapper = match get_wallet(handle) {
-        Ok(w) => w,
-        Err(e) => return e,
-    };
-
-    if account_id.is_null() || out_result.is_null() {
-        print_error("Null pointer argument");
-        return WalletFfiError::NullPointer;
-    }
-
-    let wallet = match wrapper.core.lock() {
-        Ok(w) => w,
-        Err(e) => {
-            print_error(format!("Failed to lock wallet: {e}"));
-            return WalletFfiError::InternalError;
-        }
-    };
-
-    let account_id = AccountId::new(unsafe { (*account_id).data });
-
-    let transfer = NativeTokenTransfer(&wallet);
-
-    match block_on(transfer.register_account(AccountIdentity::Public(account_id))) {
-        Ok(tx_hash) => {
-            let tx_hash = CString::new(tx_hash.to_string())
-                .map_or(ptr::null_mut(), std::ffi::CString::into_raw);
-
-            unsafe {
-                (*out_result).tx_hash = tx_hash;
-                (*out_result).success = true;
-            }
-            WalletFfiError::Success
-        }
-        Err(e) => {
-            print_error(format!("Registration failed: {e:?}"));
-            unsafe {
-                (*out_result).tx_hash = ptr::null_mut();
-                (*out_result).success = false;
-            }
-            map_execution_error(e)
-        }
-    }
-}
-
 /// Register a private account on the network.
 ///
 /// This initializes a private account. The account must be
@@ -713,7 +645,7 @@ pub unsafe extern "C" fn wallet_ffi_register_private_account(
 }
 
 /// Free a transfer result returned by `wallet_ffi_transfer_public` or
-/// `wallet_ffi_register_public_account`.
+/// `wallet_ffi_register_private_account`.
 ///
 /// # Safety
 /// The result must be either null or a valid result from a transfer function.

--- a/lez/wallet-ffi/wallet_ffi.h
+++ b/lez/wallet-ffi/wallet_ffi.h
@@ -108,6 +108,10 @@ typedef enum WalletFfiError {
    */
   INVALID_BYTECODE = 17,
   /**
+   * Fee payer cannot fund the fee reserve.
+   */
+  PAYER_CANNOT_FUND = 18,
+  /**
    * Internal error (catch-all).
    */
   INTERNAL_ERROR = 99,
@@ -1238,6 +1242,9 @@ enum WalletFfiError wallet_ffi_get_current_block_height(struct WalletHandle *han
  *
  * Transfers tokens from one public account to another on the network.
  *
+ * If `to` is a fresh, unclaimed account whose key this wallet holds, the
+ * transfer also signs with that key and claims the account.
+ *
  * # Parameters
  * - `handle`: Valid wallet handle
  * - `from`: Source account ID (must be owned by this wallet)
@@ -1450,33 +1457,6 @@ enum WalletFfiError wallet_ffi_transfer_private_owned(struct WalletHandle *handl
                                                       struct FfiTransferResult *out_result);
 
 /**
- * Register a public account on the network.
- *
- * This initializes a public account on the blockchain. The account must be
- * owned by this wallet.
- *
- * # Parameters
- * - `handle`: Valid wallet handle
- * - `account_id`: Account ID to register
- * - `out_result`: Output pointer for registration result
- *
- * # Returns
- * - `Success` if the registration was submitted successfully
- * - Error code on failure
- *
- * # Memory
- * The result must be freed with `wallet_ffi_free_transfer_result()`.
- *
- * # Safety
- * - `handle` must be a valid wallet handle from `wallet_ffi_create_new` or `wallet_ffi_open`
- * - `account_id` must be a valid pointer to a `FfiBytes32` struct
- * - `out_result` must be a valid pointer to a `FfiTransferResult` struct
- */
-enum WalletFfiError wallet_ffi_register_public_account(struct WalletHandle *handle,
-                                                       const struct FfiBytes32 *account_id,
-                                                       struct FfiTransferResult *out_result);
-
-/**
  * Register a private account on the network.
  *
  * This initializes a private account. The account must be
@@ -1505,7 +1485,7 @@ enum WalletFfiError wallet_ffi_register_private_account(struct WalletHandle *han
 
 /**
  * Free a transfer result returned by `wallet_ffi_transfer_public` or
- * `wallet_ffi_register_public_account`.
+ * `wallet_ffi_register_private_account`.
  *
  * # Safety
  * The result must be either null or a valid result from a transfer function.

--- a/lez/wallet/src/lib.rs
+++ b/lez/wallet/src/lib.rs
@@ -122,8 +122,8 @@ impl ExecutionFailureKind {
         let Self::SequencerClientError(sequencer_service_rpc::ClientError::Call(err)) = self else {
             return None;
         };
-        err.data()
-            .and_then(|data| serde_json::from_str(data.get()).ok())
+        let data = err.data()?;
+        serde_json::from_str(data.get()).ok()
     }
 }
 

--- a/lez/wallet/src/lib.rs
+++ b/lez/wallet/src/lib.rs
@@ -30,6 +30,7 @@ use lee_core::{
     program::InstructionData,
 };
 use log::warn;
+pub use sequencer_service_rpc::AdmissionRejection;
 use sequencer_service_rpc::{RpcClient as _, SequencerClient};
 use storage::Storage;
 use tokio::io::AsyncWriteExt as _;
@@ -110,6 +111,20 @@ pub enum ExecutionFailureKind {
     MultiSequencerTransactionSendError,
     #[error("Failed to join a task: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+}
+
+impl ExecutionFailureKind {
+    /// The structured fee-admission rejection behind a sequencer refusal, if
+    /// that is what this failure is, decoded from the JSON-RPC error's `data`
+    /// field.
+    #[must_use]
+    pub fn fee_admission_rejection(&self) -> Option<AdmissionRejection> {
+        let Self::SequencerClientError(sequencer_service_rpc::ClientError::Call(err)) = self else {
+            return None;
+        };
+        err.data()
+            .and_then(|data| serde_json::from_str(data.get()).ok())
+    }
 }
 
 pub struct WalletCore {
@@ -1157,5 +1172,28 @@ mod tests {
         let mn_ret = Mnemonic::from_str(mn_string).unwrap();
 
         assert_eq!(mnemonic, mn_ret);
+    }
+
+    #[test]
+    fn fee_admission_rejection_is_decoded_from_the_rpc_error_data() {
+        use sequencer_service_rpc::{AdmissionRejection, ClientError, ErrorObjectOwned};
+
+        use crate::ExecutionFailureKind;
+
+        let rejection = AdmissionRejection::PayerCannotFund {
+            payer: lee::AccountId::new([7; 32]),
+            balance: 0,
+            fee_reserve: 42,
+        };
+        let failure = ExecutionFailureKind::SequencerClientError(ClientError::Call(
+            ErrorObjectOwned::owned(rejection.code(), rejection.to_string(), Some(&rejection)),
+        ));
+        assert_eq!(failure.fee_admission_rejection(), Some(rejection));
+
+        assert!(
+            ExecutionFailureKind::InsufficientFundsError
+                .fee_admission_rejection()
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## 🎯 Purpose

FFI follow-up to #801: make the fee subsystem visible and usable across both C FFI surfaces.
- wallet FFI could not distinguish a fee-admission refusal from a generic network error, and still exposed the public-account `Initialize` path that is removed now
- the indexer FFI silently dropped the fee declaration, so the explorer had no way to show what a transaction declared.

## ⚙️ Approach

**Wallet FFI**
- [x] Add `WalletFfiError::PayerCannotFund` (18) and map the sequencer's fee-admission rejection to it in `map_execution_error`
- [x] Add `ExecutionFailureKind::fee_admission_rejection()` in `wallet`, decoding the structured `AdmissionRejection` from the JSON-RPC error's `data` field (`sequencer_service_rpc` now re-exports `AdmissionRejection` / `ErrorObjectOwned` for this)
- [x] Remove `wallet_ffi_register_public_account`: a bare `Initialize`'s only signer is the unfunded fresh account, which cannot pay, so it is refused at admission by design. A public account is claimed by its first funded transfer instead — `wallet_ffi_transfer_public` already does this (it signs with the recipient's key when the wallet holds it) and its docs now say so. Private registration is unaffected.

**Indexer FFI**
- [x] Carry the fee declaration over the FFI: new inline `FfiFeeDeclaration { payer, gas_limit, tip, max_fee }` plus `has_fee` on `FfiPublicMessage` (no heap allocation, so the free path is unchanged); resolves both `FIXME`s

## 🧪 How to Test

```sh
# Rejection decode + fee roundtrip unit tests
RISC0_DEV_MODE=1 cargo test -p wallet fee_admission_rejection
RISC0_DEV_MODE=1 cargo test -p indexer_ffi fee_roundtrips

# End-to-end claim-by-funded-transfer over the wallet FFI
RISC0_DEV_MODE=1 cargo test -p integration_tests --test wallet_ffi -- wallet_ffi_public_account_is_claimed_by_funded_transfer
```

## 🔗 Dependencies

None.

## 🔜 Future Work

- Bump the logos-execution-zone flake input in lez-indexer-module / logos-execution-zone-module and rebuild against the new headers: wallet_ffi_register_public_account is gone (migrate callers to a funded wallet_ffi_transfer_public), and FfiPublicMessage's layout changed.
- Surface the fee in the explorer UI once the module is bumped.
- Other admission rejections (`MaxFeeBelowReserve`, …) still map to the generic error codes; dedicated codes can be added the same way if consumers need them.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments