### PR TITLE
perf(lee): memoize guest memory images, keyed by ELF bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5630,6 +5630,7 @@ dependencies = [
  "rand 0.8.6",
  "risc0-binfmt",
  "risc0-zkvm",
+ "semver",
  "serde_with",
  "sha2 0.10.9",
  "test-case",

--- a/lee/state_machine/Cargo.toml
+++ b/lee/state_machine/Cargo.toml
@@ -21,6 +21,7 @@ borsh.workspace = true
 hex.workspace = true
 k256.workspace = true
 risc0-binfmt = "3.0.2"
+semver = { version = "1", optional = true }
 log.workspace = true
 
 [build-dependencies]
@@ -35,5 +36,5 @@ test-case = "3.3.1"
 
 [features]
 default = []
-prove = ["risc0-zkvm/prove"]
+prove = ["risc0-zkvm/prove", "dep:semver"]
 test-utils = []

--- a/lee/state_machine/src/lib.rs
+++ b/lee/state_machine/src/lib.rs
@@ -55,6 +55,24 @@ mod test_methods {
         )
     }
 
+    #[cfg(feature = "prove")]
+    #[must_use]
+    pub const fn multi_segment_burner() -> Program {
+        Program::new_unchecked(
+            test_methods::MULTI_SEGMENT_BURNER_ID,
+            Cow::Borrowed(test_methods::MULTI_SEGMENT_BURNER_ELF),
+        )
+    }
+
+    #[cfg(feature = "prove")]
+    #[must_use]
+    pub const fn panics_with_session_limit_text() -> Program {
+        Program::new_unchecked(
+            test_methods::PANICS_WITH_SESSION_LIMIT_TEXT_ID,
+            Cow::Borrowed(test_methods::PANICS_WITH_SESSION_LIMIT_TEXT_ELF),
+        )
+    }
+
     #[must_use]
     pub const fn malformed_journal() -> Program {
         Program::new_unchecked(

--- a/lee/state_machine/src/program/image_cache/mod.rs
+++ b/lee/state_machine/src/program/image_cache/mod.rs
@@ -1,0 +1,171 @@
+//! Process-global cache of built `MemoryImage`s, keyed by the ELF bytes themselves.
+//!
+//! Keyed on bytes rather than `Program::id`, which `Program::new_unchecked` lets diverge: serving
+//! an image built from bytes other than the ones being charged for is a consensus fault. A
+//! per-process seeded hash picks the slot and a full byte comparison confirms it, so a collision
+//! skips the cache rather than returning the wrong image.
+
+use std::{
+    collections::{HashMap, hash_map::RandomState},
+    hash::{BuildHasher as _, Hasher as _},
+    sync::{Arc, Mutex, MutexGuard, OnceLock},
+};
+
+use anyhow::{Result, bail};
+use risc0_binfmt::{AbiKind, MemoryImage, ProgramBinary, ProgramBinaryHeader};
+use risc0_zkvm::{ExecutorEnv, ExecutorImpl, NullSegmentRef};
+
+use super::SessionOutcome;
+
+#[cfg(test)]
+mod tests;
+
+/// Bytes held at once. Programs are user-deployable, so the budget is bytes rather than a count
+/// of entries, and the least recently used entry is evicted first.
+const MAX_CACHED_BYTES: usize = 32 * 1024 * 1024;
+
+/// Mirrors risc0's private `check_program_version`: a different value would accept guests the
+/// proving path rejects.
+const SUPPORTED_ABI: &str = "^1.0.0";
+
+struct Entry {
+    elf: Box<[u8]>,
+    image: Arc<MemoryImage>,
+    bytes: usize,
+    used: u64,
+}
+
+#[derive(Default)]
+struct Cache {
+    entries: HashMap<u64, Entry>,
+    bytes: usize,
+    tick: u64,
+}
+
+fn cache() -> MutexGuard<'static, Cache> {
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| Mutex::new(Cache::default()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Slot selector over the whole ELF, seeded once per process so colliding bytes cannot be
+/// constructed by whoever supplies the program.
+pub fn slot(elf: &[u8]) -> u64 {
+    static SEED: OnceLock<RandomState> = OnceLock::new();
+    let mut hasher = SEED.get_or_init(RandomState::new).build_hasher();
+    hasher.write(elf);
+    hasher.finish()
+}
+
+/// What an entry costs to hold: the ELF copy plus its image. An upper bound, not a measurement,
+/// since `MemoryImage` does not expose its size and measured images come in under their ELF. Only
+/// moves when eviction starts.
+const fn footprint(elf: &[u8]) -> usize {
+    elf.len().saturating_mul(2)
+}
+
+/// The image for these exact bytes, marked most recently used. A slot holding different bytes is
+/// a miss, never a substitution.
+fn cached(key: u64, elf: &[u8]) -> Option<Arc<MemoryImage>> {
+    let mut guard = cache();
+    guard.tick = guard.tick.wrapping_add(1);
+    let tick = guard.tick;
+    let entry = guard.entries.get_mut(&key)?;
+    if &*entry.elf != elf {
+        return None;
+    }
+    entry.used = tick;
+    Some(Arc::clone(&entry.image))
+}
+
+/// Records an image that has just executed cleanly, evicting to stay inside the budget.
+fn remember(key: u64, elf: &[u8], image: &Arc<MemoryImage>) {
+    let bytes = footprint(elf);
+    if bytes > MAX_CACHED_BYTES {
+        return;
+    }
+    let mut guard = cache();
+    if guard.entries.contains_key(&key) {
+        return;
+    }
+    while guard.bytes.saturating_add(bytes) > MAX_CACHED_BYTES {
+        let Some(victim) = guard
+            .entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.used)
+            .map(|(slot, _)| *slot)
+        else {
+            break;
+        };
+        if let Some(evicted) = guard.entries.remove(&victim) {
+            guard.bytes = guard.bytes.saturating_sub(evicted.bytes);
+        }
+    }
+    guard.tick = guard.tick.wrapping_add(1);
+    let used = guard.tick;
+    guard.bytes = guard.bytes.saturating_add(bytes);
+    guard.entries.insert(
+        key,
+        Entry {
+            elf: elf.into(),
+            image: Arc::clone(image),
+            bytes,
+            used,
+        },
+    );
+}
+
+/// `ExecutorImpl::from_elf` runs this before building the image; `ExecutorImpl::new` does not, so
+/// the cached path has to do it itself or an incompatible guest would silently start executing.
+fn check_program_version(header: &ProgramBinaryHeader) -> Result<()> {
+    if header.abi_kind != AbiKind::V1Compat {
+        bail!(
+            "ProgramBinary abi_kind mismatch {:?} != AbiKind::V1Compat",
+            header.abi_kind
+        );
+    }
+    if !semver::VersionReq::parse(SUPPORTED_ABI)
+        .expect("static requirement parses")
+        .matches(&header.abi_version)
+    {
+        bail!(
+            "ProgramBinary abi_version mismatch {} doesn't match {SUPPORTED_ABI}",
+            header.abi_version
+        );
+    }
+    Ok(())
+}
+
+/// In-process no-proof execution against the cached image.
+///
+/// Mirrors `<LocalProver as Executor>::execute`, except the image comes from the cache and a
+/// malformed ELF is returned as an error instead of panicking.
+pub fn execute(env: ExecutorEnv<'_>, elf: &[u8]) -> Result<SessionOutcome> {
+    let key = slot(elf);
+    let image = if let Some(image) = cached(key, elf) {
+        image
+    } else {
+        let binary = ProgramBinary::decode(elf)?;
+        check_program_version(&binary.header)?;
+        Arc::new(binary.to_image()?)
+    };
+
+    let session = ExecutorImpl::new(env, (*image).clone())?
+        .run_with_callback(|_| Ok(Box::new(NullSegmentRef)))?;
+    // The replaced path builds the claim and propagates its failure; a session it would reject
+    // must not be accepted here.
+    session.claim()?;
+
+    // Only after a clean run: caching on the way in lets one cheap failing call pin an entry.
+    remember(key, elf, &image);
+
+    Ok(SessionOutcome {
+        journal: session
+            .journal
+            .map(|journal| journal.bytes)
+            .unwrap_or_default(),
+        cycles: session.user_cycles,
+    })
+}

--- a/lee/state_machine/src/program/image_cache/tests.rs
+++ b/lee/state_machine/src/program/image_cache/tests.rs
@@ -1,0 +1,359 @@
+//! Measurement and equivalence harness for the memoized-`MemoryImage` execution path.
+//!
+//! Run with `--nocapture`. `RISC0_EXECUTOR=ipc` switches the baseline leg to the
+//! out-of-process r0vm executor; the cached leg is unaffected by that variable.
+
+use lee_core::{
+    account::{Account, AccountId, AccountWithMetadata, Cycles},
+    program::ProgramInput,
+    to_borsh_frame, to_frame,
+};
+use risc0_binfmt::ProgramBinary;
+use risc0_zkvm::{ExecutorEnv, ExecutorImpl, default_executor};
+
+use crate::{
+    error::LeeError,
+    program::{DEFAULT_PUBLIC_CYCLE_BUDGET, Program, SessionOutcome},
+};
+
+fn transfer_pre_states() -> Vec<AccountWithMetadata> {
+    vec![
+        AccountWithMetadata::new(
+            Account {
+                balance: 77_665_544_332_211,
+                ..Account::default()
+            },
+            true,
+            AccountId::new([0; 32]),
+        ),
+        AccountWithMetadata::new(Account::default(), false, AccountId::new([1; 32])),
+    ]
+}
+
+/// An env carrying nothing but the cycle budget, for the guests that read no input.
+fn bare_env(budget: Cycles) -> ExecutorEnv<'static> {
+    let mut builder = ExecutorEnv::builder();
+    builder.session_limit(Some(budget));
+    builder.build().expect("env builds")
+}
+
+/// A fresh `ExecutorEnv` carrying the same inputs `Program::execute` would write.
+fn env_for(
+    program: &Program,
+    pre_states: &[AccountWithMetadata],
+    instruction: &[u8],
+    budget: Cycles,
+) -> ExecutorEnv<'static> {
+    let mut builder = ExecutorEnv::builder();
+    builder.session_limit(Some(budget));
+    program
+        .write_inputs(
+            AccountId::from(program.id()),
+            None,
+            pre_states,
+            instruction,
+            &mut builder,
+        )
+        .expect("inputs write");
+    builder.build().expect("env builds")
+}
+
+/// The pre-change code path: rebuild the image from the ELF on every call.
+fn baseline(env: ExecutorEnv<'_>, elf: &[u8]) -> anyhow::Result<SessionOutcome> {
+    let info = default_executor().execute(env, elf)?;
+    Ok(SessionOutcome {
+        journal: info.journal.bytes.clone(),
+        cycles: info.cycles(),
+    })
+}
+
+/// Journal bytes and cycle counts must match between the two paths, on several
+/// real programs with several shapes of input.
+#[test]
+fn cached_path_matches_rebuild_path() {
+    let cases: Vec<(&str, Program, Vec<AccountWithMetadata>, Vec<u8>)> = vec![
+        (
+            "simple_balance_transfer",
+            crate::test_methods::simple_balance_transfer(),
+            transfer_pre_states(),
+            Program::serialize_instruction(11_223_344_556_677_u128).unwrap(),
+        ),
+        (
+            "noop",
+            crate::test_methods::noop(),
+            transfer_pre_states(),
+            Vec::new(),
+        ),
+        (
+            "data_changer",
+            crate::test_methods::data_changer(),
+            vec![AccountWithMetadata::new(
+                Account::default(),
+                true,
+                AccountId::new([3; 32]),
+            )],
+            Program::serialize_instruction(vec![9_u8; 32]).unwrap(),
+        ),
+        (
+            "squatter",
+            crate::test_methods::squatter(),
+            transfer_pre_states(),
+            Program::serialize_instruction((vec![7_u8; 8], 5_u128)).unwrap(),
+        ),
+        (
+            "malformed_journal",
+            crate::test_methods::malformed_journal(),
+            Vec::new(),
+            Vec::new(),
+        ),
+    ];
+
+    for (name, program, pre_states, instruction) in cases {
+        let a = baseline(
+            env_for(
+                &program,
+                &pre_states,
+                &instruction,
+                DEFAULT_PUBLIC_CYCLE_BUDGET,
+            ),
+            program.elf(),
+        );
+        let b = super::execute(
+            env_for(
+                &program,
+                &pre_states,
+                &instruction,
+                DEFAULT_PUBLIC_CYCLE_BUDGET,
+            ),
+            program.elf(),
+        );
+
+        match (a, b) {
+            (Ok(a), Ok(b)) => {
+                assert_eq!(a.journal, b.journal, "{name}: journal bytes differ");
+                assert_eq!(a.cycles, b.cycles, "{name}: cycle counts differ");
+            }
+            (Err(_), Err(_)) => {}
+            (a, b) => panic!(
+                "{name}: paths disagree on success. baseline_ok={} cached_ok={}",
+                a.is_ok(),
+                b.is_ok()
+            ),
+        }
+    }
+}
+
+/// The session-limit bail must still be recognized in-process. Prints the raw
+/// error text from both paths so any wording drift is visible.
+#[test]
+fn session_limit_still_maps_to_out_of_gas() {
+    let program = crate::test_methods::simple_balance_transfer();
+    let pre_states = transfer_pre_states();
+    let instruction = Program::serialize_instruction(11_223_344_556_677_u128).unwrap();
+    let budget: Cycles = 1_024;
+
+    let base_err = baseline(
+        env_for(&program, &pre_states, &instruction, budget),
+        program.elf(),
+    )
+    .expect_err("tiny budget must bail");
+
+    let cached_err = super::execute(
+        env_for(&program, &pre_states, &instruction, budget),
+        program.elf(),
+    )
+    .expect_err("tiny budget must bail");
+
+    for (path, err) in [("baseline", &base_err), ("cached", &cached_err)] {
+        assert!(
+            format!("{err:#}").contains("Session limit exceeded"),
+            "{path} no longer reports the session limit, the OutOfGas match breaks: {err:#}"
+        );
+    }
+
+    // The mapping itself, through the real function.
+    let mapped = Program::execute_session(
+        env_for(&program, &pre_states, &instruction, budget),
+        program.elf(),
+        budget,
+    )
+    .expect_err("tiny budget must bail");
+    assert!(
+        matches!(mapped, LeeError::OutOfGas { budget: b } if b == budget),
+        "session limit no longer maps to OutOfGas: {mapped:?}"
+    );
+}
+
+/// A guest panic must not be mistaken for out-of-gas, including when the panic message
+/// itself contains the session-limit phrase.
+#[test]
+fn guest_panic_is_not_out_of_gas() {
+    let program = crate::test_methods::simple_balance_transfer();
+
+    // No input at all: `read_lee_call` panics inside the guest.
+    let cached_panic = super::execute(bare_env(DEFAULT_PUBLIC_CYCLE_BUDGET), program.elf())
+        .expect_err("guest must panic on missing input");
+
+    let base_panic = baseline(bare_env(DEFAULT_PUBLIC_CYCLE_BUDGET), program.elf())
+        .expect_err("guest must panic on missing input");
+
+    for (path, err) in [("baseline", &base_panic), ("cached", &cached_panic)] {
+        assert!(
+            format!("{err:#}").contains("Guest panicked"),
+            "{path} no longer reports a guest panic, the spoofing guard breaks: {err:#}"
+        );
+    }
+
+    let mapped = Program::execute_session(
+        bare_env(DEFAULT_PUBLIC_CYCLE_BUDGET),
+        program.elf(),
+        DEFAULT_PUBLIC_CYCLE_BUDGET,
+    )
+    .expect_err("guest must panic on missing input");
+    assert!(
+        !matches!(mapped, LeeError::OutOfGas { .. }),
+        "guest panic misclassified as OutOfGas: {mapped:?}"
+    );
+
+    // And the spoofing case the string match exists to defend against: a guest that
+    // panics with the literal session-limit phrase.
+    let spoof = crate::test_methods::panics_with_session_limit_text();
+    let mut builder = ExecutorEnv::builder();
+    builder.session_limit(Some(DEFAULT_PUBLIC_CYCLE_BUDGET));
+    builder.write_slice(&to_borsh_frame(&lee_core::program::CallKind::Execute));
+    let input = ProgramInput {
+        self_account_id: spoof.id().into(),
+        caller_account_id: None,
+        pre_states: Vec::new(),
+        instruction: Vec::<u8>::new(),
+    };
+    builder.write_slice(&to_frame(&borsh::to_vec(&input).unwrap()));
+    let spoofed = Program::execute_session(
+        builder.build().unwrap(),
+        spoof.elf(),
+        DEFAULT_PUBLIC_CYCLE_BUDGET,
+    )
+    .expect_err("spoofing guest must fail");
+    assert!(
+        !matches!(spoofed, LeeError::OutOfGas { .. }),
+        "spoofed session-limit panic misclassified as OutOfGas: {spoofed:?}"
+    );
+}
+
+/// The cache must key on the bytes, not on a caller-supplied id: two `Program`s sharing an
+/// id but not an ELF must still each get their own image.
+#[test]
+fn cache_is_keyed_on_elf_bytes_not_program_id() {
+    let a = crate::test_methods::simple_balance_transfer();
+    let b = crate::test_methods::noop();
+
+    // `new_unchecked` lets the id lie; the cache must not care.
+    let liar = Program::new_unchecked(a.id(), std::borrow::Cow::Owned(b.elf().to_vec()));
+    assert_eq!(liar.id(), a.id());
+    assert_ne!(liar.elf(), a.elf());
+    assert_eq!(super::slot(liar.elf()), super::slot(b.elf()));
+
+    // Populate the cache under `a`'s id first, so an id-keyed cache would now be primed to
+    // hand `a`'s image back for `liar`.
+    let warm = super::execute(
+        env_for(
+            &a,
+            &transfer_pre_states(),
+            &Program::serialize_instruction(1_u128).unwrap(),
+            DEFAULT_PUBLIC_CYCLE_BUDGET,
+        ),
+        a.elf(),
+    )
+    .unwrap();
+    std::hint::black_box(warm);
+
+    let pre_states = transfer_pre_states();
+    let honest = super::execute(
+        env_for(&b, &pre_states, &[], DEFAULT_PUBLIC_CYCLE_BUDGET),
+        b.elf(),
+    )
+    .unwrap();
+    let via_liar = super::execute(
+        env_for(&b, &pre_states, &[], DEFAULT_PUBLIC_CYCLE_BUDGET),
+        liar.elf(),
+    )
+    .unwrap();
+    assert_eq!(honest.journal, via_liar.journal);
+    assert_eq!(honest.cycles, via_liar.cycles);
+}
+
+/// A session that spans several continuation segments. `SessionInfo::cycles()` sums the
+/// per-segment counts while the in-process path reads `Session::user_cycles`; on a single-segment
+/// run those cannot disagree, so this is the case that actually tests the substitution.
+#[test]
+fn multi_segment_session_agrees_on_cycles_and_journal() {
+    let program = crate::test_methods::multi_segment_burner();
+
+    let base = baseline(bare_env(DEFAULT_PUBLIC_CYCLE_BUDGET), program.elf()).expect("burner runs");
+
+    let cached =
+        super::execute(bare_env(DEFAULT_PUBLIC_CYCLE_BUDGET), program.elf()).expect("burner runs");
+
+    assert!(
+        base.cycles > (1 << 20),
+        "burner did not span multiple segments: {} cycles",
+        base.cycles
+    );
+    assert_eq!(base.journal, cached.journal);
+    assert_eq!(
+        base.cycles, cached.cycles,
+        "multi-segment cycle accounting differs"
+    );
+}
+
+/// A malformed ELF is an error here. `LocalProver::execute` unwraps `ExecutorImpl::from_elf`, so
+/// the same bytes abort the thread on the pre-change path whenever `prove` is on.
+#[test]
+fn malformed_elf_is_an_error_not_a_panic() {
+    let program = crate::test_methods::simple_balance_transfer();
+    let truncated = &program.elf()[..64];
+
+    super::execute(bare_env(DEFAULT_PUBLIC_CYCLE_BUDGET), truncated)
+        .expect_err("a truncated ProgramBinary must not build an image");
+}
+
+/// A guest whose ABI risc0 rejects must be rejected on the cached path too. `ExecutorImpl::new`
+/// skips the check `from_elf` performs, so the cached path hand-copies it; this is what fails if
+/// that copy ever drifts from upstream.
+#[test]
+fn incompatible_abi_is_rejected_on_both_paths() {
+    let good = crate::test_methods::noop();
+    let decoded = ProgramBinary::decode(good.elf()).expect("a committed guest decodes");
+
+    let mut bad = ProgramBinary::new(decoded.user_elf, decoded.kernel_elf);
+    bad.header.abi_version = semver::Version::new(2, 0, 0);
+    let blob = bad.encode();
+
+    let upstream = ExecutorImpl::from_elf(
+        env_for(
+            &good,
+            &transfer_pre_states(),
+            &[],
+            DEFAULT_PUBLIC_CYCLE_BUDGET,
+        ),
+        &blob,
+    );
+    assert!(
+        upstream.is_err(),
+        "risc0 no longer rejects abi_version 2.0.0; the copied check needs revisiting"
+    );
+
+    let ours = super::execute(
+        env_for(
+            &good,
+            &transfer_pre_states(),
+            &[],
+            DEFAULT_PUBLIC_CYCLE_BUDGET,
+        ),
+        &blob,
+    );
+    assert!(
+        ours.is_err(),
+        "the cached path accepted a guest risc0 rejects"
+    );
+}

--- a/lee/state_machine/src/program/mod.rs
+++ b/lee/state_machine/src/program/mod.rs
@@ -7,14 +7,31 @@ use lee_core::{
     program::{CallKind, InstructionData, ProgramId, ProgramInput, ProgramOutput},
     to_borsh_frame, to_frame,
 };
-use risc0_zkvm::{ExecutorEnv, ExecutorEnvBuilder, default_executor};
+#[cfg(not(feature = "prove"))]
+use risc0_zkvm::default_executor;
+use risc0_zkvm::{ExecutorEnv, ExecutorEnvBuilder};
 
 use crate::error::LeeError;
+
+#[cfg(feature = "prove")]
+pub(crate) mod image_cache;
+
+#[cfg(test)]
+mod tests;
 
 /// The cycle budget applied to public execution paths that do not carry a
 /// transaction-specific budget; charged transactions supply their own
 /// `gas_limit` instead.
 pub const DEFAULT_PUBLIC_CYCLE_BUDGET: Cycles = 1024 * 1024 * 32; // 32M cycles
+
+/// What `execute_session` needs off a no-proof run: the committed journal and the user-cycle
+/// count. Narrower than `risc0_zkvm::SessionInfo`, which is `#[non_exhaustive]` and so cannot be
+/// built outside risc0.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SessionOutcome {
+    pub journal: Vec<u8>,
+    pub cycles: Cycles,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Program {
@@ -76,11 +93,11 @@ impl Program {
         let env = env_builder.build().unwrap();
 
         // Execute the program (without proving)
-        let session_info = Self::execute_session(env, self.elf(), cycle_budget)?;
-        let cycles = session_info.cycles();
+        let session = Self::execute_session(env, self.elf(), cycle_budget)?;
+        let cycles = session.cycles;
 
         // Get outputs
-        let payload = from_frame(&session_info.journal.bytes).ok_or_else(|| {
+        let payload = from_frame(&session.journal).ok_or_else(|| {
             LeeError::ProgramExecutionFailed("malformed program journal frame".to_owned())
         })?;
         let program_output = borsh::from_slice(payload)
@@ -94,12 +111,24 @@ impl Program {
     /// recognized.
     ///
     /// FIXME: This is a brittle string match; the executor should provide a typed error.
-    fn execute_session(
+    pub(crate) fn execute_session(
         env: ExecutorEnv<'_>,
         elf: &[u8],
         cycle_budget: Cycles,
-    ) -> Result<risc0_zkvm::SessionInfo, LeeError> {
-        default_executor().execute(env, elf).map_err(|e| {
+    ) -> Result<SessionOutcome, LeeError> {
+        #[cfg(feature = "prove")]
+        let raw = image_cache::execute(env, elf);
+        #[cfg(not(feature = "prove"))]
+        let raw = default_executor().execute(env, elf).map(|info| {
+            // Cycles first so the journal moves instead of cloning.
+            let cycles = info.cycles();
+            SessionOutcome {
+                journal: info.journal.bytes,
+                cycles,
+            }
+        });
+
+        raw.map_err(|e| {
             // check for "Guest panicked" to prevent spoofing
             // via `panic!("Session limit exceeded")` cases
             let message = format!("{e:#}");
@@ -137,6 +166,3 @@ impl Program {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests;

--- a/lee/state_machine/test_methods/guest/src/bin/multi_segment_burner.rs
+++ b/lee/state_machine/test_methods/guest/src/bin/multi_segment_burner.rs
@@ -1,0 +1,9 @@
+//! Burns enough cycles to span several continuation segments, so the two execution paths can be
+//! compared on a session where per-segment and whole-session cycle accounting could disagree.
+fn main() {
+    let mut acc: u32 = 1;
+    for i in 0..2_000_000_u32 {
+        acc = acc.wrapping_mul(2_654_435_761).wrapping_add(i);
+    }
+    risc0_zkvm::guest::env::commit_slice(&acc.to_le_bytes());
+}

--- a/lee/state_machine/test_methods/guest/src/bin/panics_with_session_limit_text.rs
+++ b/lee/state_machine/test_methods/guest/src/bin/panics_with_session_limit_text.rs
@@ -1,0 +1,7 @@
+//! Panics with the exact phrase the host matches on to detect a session-limit bail, so the
+//! "Guest panicked" exclusion in `Program::execute_session` has something real to defend against.
+fn main() {
+    // Keeps the zkVM runtime linked in; without a reference to it the guest has no entry point.
+    let _ = risc0_zkvm::guest::env::cycle_count();
+    panic!("Session limit exceeded: 1 >= 0");
+}

--- a/lez/storage/Cargo.toml
+++ b/lez/storage/Cargo.toml
@@ -24,3 +24,7 @@ zstd.workspace = true
 lee_core = { workspace = true, features = ["host"] }
 programs.workspace = true
 system_accounts.workspace = true
+
+[features]
+# Runs guest execution in-process against the memoized image cache.
+prove = ["lee/prove"]


### PR DESCRIPTION
## 🎯 Purpose

Guest execution rebuilds the MemoryImage from the ELF on every call. That build
is ~10.4ms of an ~11.7ms in-process execution; the emulation itself is ~0.5ms.
The same few programs run over and over, so the image is identical every time
and thrown away every time.

This speeds up CI and `wallet-ffi`; the node still uses r0vm until `prove` is
enabled there.

## ⚙️ Approach

- Cache built `MemoryImage`s, byte-bounded with LRU eviction, recorded only
  after a clean run
- Keyed on ELF bytes, since `new_unchecked` lets `Program::id` diverge from
  them. A collision skips the cache, it never returns the wrong image
- Runs the ABI check and the claim the replaced path performs
- Under `prove` only; without it the executor is unchanged

Per call under `--all-features`: 11.74ms → 1.325ms. `-p storage`
`state_replay_falls_back_over_missing_breakpoints` 51s → 3.5s,
`put_block_stores_breakpoint_in_same_batch` 33s → 2.0s.

## 🧪 How to Test

```sh
RISC0_DEV_MODE=1 cargo test --release -p lee --features prove
RISC0_DEV_MODE=1 cargo test --release -p storage --features prove
```

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments

