### PR TITLE
feat(state_machine): handle non-zero program exit codes

### DIFF
--- a/lee/state_machine/src/error.rs
+++ b/lee/state_machine/src/error.rs
@@ -44,6 +44,9 @@ pub enum LeeError {
     #[error("Failed to execute program: {0}")]
     ProgramExecutionFailed(String),
 
+    #[error("Program exited with non-zero code {code} after {cycles} cycles")]
+    ProgramExitedWithCode { code: u32, cycles: Cycles },
+
     #[error("Failed to prove program: {0}")]
     ProgramProveFailed(String),
 

--- a/lee/state_machine/src/lib.rs
+++ b/lee/state_machine/src/lib.rs
@@ -82,6 +82,14 @@ mod test_methods {
     }
 
     #[must_use]
+    pub const fn exits_nonzero() -> Program {
+        Program::new_unchecked(
+            test_methods::EXITS_NONZERO_ID,
+            Cow::Borrowed(test_methods::EXITS_NONZERO_ELF),
+        )
+    }
+
+    #[must_use]
     pub const fn dropped_account() -> Program {
         Program::new_unchecked(
             test_methods::DROPPED_ACCOUNT_ID,

--- a/lee/state_machine/src/privacy_preserving_transaction/circuit/mod.rs
+++ b/lee/state_machine/src/privacy_preserving_transaction/circuit/mod.rs
@@ -11,7 +11,7 @@ use lee_core::{
     },
     to_frame,
 };
-use risc0_zkvm::{ExecutorEnv, InnerReceipt, ProverOpts, Receipt, default_prover};
+use risc0_zkvm::{ExecutorEnv, ExitCode, InnerReceipt, ProverOpts, Receipt, default_prover};
 
 use crate::{
     PRIVACY_PRESERVING_CIRCUIT_ELF, PRIVACY_PRESERVING_CIRCUIT_ID,
@@ -373,10 +373,33 @@ fn execute_and_prove_program(
 
     // Prove the program
     let prover = default_prover();
-    Ok(prover
+    let prove_info = prover
         .prove(env, program.elf())
+        .map_err(|e| LeeError::ProgramProveFailed(e.to_string()))?;
+
+    // The local prover proves any exit code, and the circuit's `env::verify` only resolves a
+    // `Halted(0)` claim, so gate here for a typed error before the expensive circuit proof.
+    let exit_code = prove_info
+        .receipt
+        .claim()
         .map_err(|e| LeeError::ProgramProveFailed(e.to_string()))?
-        .receipt)
+        .as_value()
+        .map_err(|e| LeeError::ProgramProveFailed(e.to_string()))?
+        .exit_code;
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "we only care about ExitCode::Halted"
+    )]
+    match exit_code {
+        ExitCode::Halted(0) => Ok(prove_info.receipt),
+        ExitCode::Halted(code) => Err(LeeError::ProgramExitedWithCode {
+            code,
+            cycles: prove_info.stats.user_cycles,
+        }),
+        other => Err(LeeError::ProgramProveFailed(format!(
+            "unexpected exit {other:?}"
+        ))),
+    }
 }
 
 #[cfg(test)]

--- a/lee/state_machine/src/privacy_preserving_transaction/circuit/mod.rs
+++ b/lee/state_machine/src/privacy_preserving_transaction/circuit/mod.rs
@@ -11,12 +11,12 @@ use lee_core::{
     },
     to_frame,
 };
-use risc0_zkvm::{ExecutorEnv, ExitCode, InnerReceipt, ProverOpts, Receipt, default_prover};
+use risc0_zkvm::{ExecutorEnv, InnerReceipt, ProverOpts, Receipt, default_prover};
 
 use crate::{
     PRIVACY_PRESERVING_CIRCUIT_ELF, PRIVACY_PRESERVING_CIRCUIT_ID,
     error::{InvalidProgramBehaviorError, LeeError},
-    program::Program,
+    program::{Program, check_exit_code},
     state::MAX_NUMBER_CHAINED_CALLS,
 };
 
@@ -386,20 +386,12 @@ fn execute_and_prove_program(
         .as_value()
         .map_err(|e| LeeError::ProgramProveFailed(e.to_string()))?
         .exit_code;
-    #[expect(
-        clippy::wildcard_enum_match_arm,
-        reason = "we only care about ExitCode::Halted"
-    )]
-    match exit_code {
-        ExitCode::Halted(0) => Ok(prove_info.receipt),
-        ExitCode::Halted(code) => Err(LeeError::ProgramExitedWithCode {
-            code,
-            cycles: prove_info.stats.user_cycles,
-        }),
-        other => Err(LeeError::ProgramProveFailed(format!(
-            "unexpected exit {other:?}"
-        ))),
-    }
+    check_exit_code(
+        exit_code,
+        prove_info.stats.user_cycles,
+        LeeError::ProgramProveFailed,
+    )?;
+    Ok(prove_info.receipt)
 }
 
 #[cfg(test)]

--- a/lee/state_machine/src/program/image_cache/mod.rs
+++ b/lee/state_machine/src/program/image_cache/mod.rs
@@ -167,5 +167,6 @@ pub fn execute(env: ExecutorEnv<'_>, elf: &[u8]) -> Result<SessionOutcome> {
             .map(|journal| journal.bytes)
             .unwrap_or_default(),
         cycles: session.user_cycles,
+        exit_code: session.exit_code,
     })
 }

--- a/lee/state_machine/src/program/image_cache/tests.rs
+++ b/lee/state_machine/src/program/image_cache/tests.rs
@@ -64,6 +64,7 @@ fn baseline(env: ExecutorEnv<'_>, elf: &[u8]) -> anyhow::Result<SessionOutcome> 
     Ok(SessionOutcome {
         journal: info.journal.bytes.clone(),
         cycles: info.cycles(),
+        exit_code: info.exit_code,
     })
 }
 

--- a/lee/state_machine/src/program/mod.rs
+++ b/lee/state_machine/src/program/mod.rs
@@ -9,7 +9,7 @@ use lee_core::{
 };
 #[cfg(not(feature = "prove"))]
 use risc0_zkvm::default_executor;
-use risc0_zkvm::{ExecutorEnv, ExecutorEnvBuilder};
+use risc0_zkvm::{ExecutorEnv, ExecutorEnvBuilder, ExitCode};
 
 use crate::error::LeeError;
 
@@ -31,6 +31,7 @@ pub const DEFAULT_PUBLIC_CYCLE_BUDGET: Cycles = 1024 * 1024 * 32; // 32M cycles
 pub(crate) struct SessionOutcome {
     pub journal: Vec<u8>,
     pub cycles: Cycles,
+    pub exit_code: ExitCode,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
@@ -109,8 +110,6 @@ impl Program {
     /// Runs the session, translating the executor's session-limit bail into the
     /// typed [`LeeError::OutOfGas`]. The only place that error string is
     /// recognized.
-    ///
-    /// FIXME: This is a brittle string match; the executor should provide a typed error.
     pub(crate) fn execute_session(
         env: ExecutorEnv<'_>,
         elf: &[u8],
@@ -125,10 +124,13 @@ impl Program {
             SessionOutcome {
                 journal: info.journal.bytes,
                 cycles,
+                exit_code: info.exit_code,
             }
         });
 
-        raw.map_err(|e| {
+        // map the r0 error to LeeError
+        // FIXME: This is a brittle string match; the executor should provide a typed error.
+        let outcome = raw.map_err(|e| {
             // check for "Guest panicked" to prevent spoofing
             // via `panic!("Session limit exceeded")` cases
             let message = format!("{e:#}");
@@ -139,7 +141,24 @@ impl Program {
             } else {
                 LeeError::ProgramExecutionFailed(e.to_string())
             }
-        })
+        })?;
+
+        // check the exit code for non-zero terminations
+        #[expect(
+            clippy::wildcard_enum_match_arm,
+            reason = "we only care about ExitCode::Halted"
+        )]
+        match outcome.exit_code {
+            ExitCode::Halted(0) => Ok(outcome),
+            ExitCode::Halted(code) => Err(LeeError::ProgramExitedWithCode {
+                code,
+                cycles: outcome.cycles,
+            }),
+            // anything other than Halted is an actual error (e.g. r0vm termination)
+            other => Err(LeeError::ProgramExecutionFailed(format!(
+                "unexpected exit {other:?}"
+            ))),
+        }
     }
 
     /// Writes a `CallKind::Execute` frame followed by the guest's `ProgramInput` as a single

--- a/lee/state_machine/src/program/mod.rs
+++ b/lee/state_machine/src/program/mod.rs
@@ -145,25 +145,12 @@ impl Program {
             }
         })?;
 
-        // check the exit code for non-zero terminations
-        #[expect(
-            clippy::wildcard_enum_match_arm,
-            reason = "we only care about ExitCode::Halted"
-        )]
-        match outcome.exit_code {
-            ExitCode::Halted(0) => Ok(outcome),
-            ExitCode::Halted(code) => Err(LeeError::ProgramExitedWithCode {
-                code,
-                cycles: outcome.cycles,
-            }),
-            // anything other than Halted is an actual error (e.g. r0vm termination)
-            //
-            // NOTE: ExitCode::SessionLimit actually exists, but r0vm does not use it
-            // see their own code for the comment
-            other => Err(LeeError::ProgramExecutionFailed(format!(
-                "unexpected exit {other:?}"
-            ))),
-        }
+        check_exit_code(
+            outcome.exit_code,
+            outcome.cycles,
+            LeeError::ProgramExecutionFailed,
+        )?;
+        Ok(outcome)
     }
 
     /// Writes a `CallKind::Execute` frame followed by the guest's `ProgramInput` as a single
@@ -188,5 +175,32 @@ impl Program {
             borsh::to_vec(&input).map_err(|e| LeeError::ProgramWriteInputFailed(e.to_string()))?;
         env_builder.write_slice(&to_frame(&payload));
         Ok(())
+    }
+}
+
+/// Gates a finished session on its exit code.
+///
+/// - `ExitCode::Halted(0)` is a success
+/// - `ExitCode::Halted(code)` with a non-zero `code` is a cycle-counted failure
+/// - `ExitCode::Paused(code)` is treated as a full failure as we do not expect `Pause`'s to occur
+/// - Any other exit code is treated as a full failure
+pub(crate) fn check_exit_code(
+    exit_code: ExitCode,
+    cycles: Cycles,
+    on_failure: fn(String) -> LeeError,
+) -> Result<(), LeeError> {
+    match exit_code {
+        ExitCode::Halted(0) => Ok(()),
+        ExitCode::Halted(code) => Err(LeeError::ProgramExitedWithCode { code, cycles }),
+        // A pause keeps its journal and count, but a program is one call to a final output and
+        // the circuit's `env::verify` only resolves a `Halted(0)` claim, so it is a plain
+        // failure on both paths and pays the full budget like a panic.
+        ExitCode::Paused(code) => Err(on_failure(format!("program paused with code {code}"))),
+        // `SystemSplit` never ends a session and `SessionLimit` is documented as never emitted
+        // (risc0-binfmt `exit_code.rs`): the executor bails with "Session limit exceeded"
+        // instead, which `execute_session` maps to `OutOfGas`.
+        ExitCode::SessionLimit | ExitCode::SystemSplit | _ => {
+            Err(on_failure(format!("unexpected exit {exit_code:?}")))
+        }
     }
 }

--- a/lee/state_machine/src/program/mod.rs
+++ b/lee/state_machine/src/program/mod.rs
@@ -157,6 +157,9 @@ impl Program {
                 cycles: outcome.cycles,
             }),
             // anything other than Halted is an actual error (e.g. r0vm termination)
+            //
+            // NOTE: ExitCode::SessionLimit actually exists, but r0vm does not use it
+            // see their own code for the comment
             other => Err(LeeError::ProgramExecutionFailed(format!(
                 "unexpected exit {other:?}"
             ))),

--- a/lee/state_machine/src/program/mod.rs
+++ b/lee/state_machine/src/program/mod.rs
@@ -128,13 +128,15 @@ impl Program {
             }
         });
 
-        // map the r0 error to LeeError
-        // FIXME: This is a brittle string match; the executor should provide a typed error.
+        // NOTE: risc0 bails with an untyped anyhow error and the r0vm IPC path
+        // flattens it to a string. the best we can do is a string match...
         let outcome = raw.map_err(|e| {
-            // check for "Guest panicked" to prevent spoofing
-            // via `panic!("Session limit exceeded")` cases
-            let message = format!("{e:#}");
-            if message.contains("Session limit exceeded") && !message.contains("Guest panicked") {
+            // check the root cause specifically to avoid spoofed errors
+            // like "Guest panicked: Session limit exceeded"
+            if e.root_cause()
+                .to_string()
+                .starts_with("Session limit exceeded:")
+            {
                 LeeError::OutOfGas {
                     budget: cycle_budget,
                 }

--- a/lee/state_machine/src/program/tests.rs
+++ b/lee/state_machine/src/program/tests.rs
@@ -213,3 +213,23 @@ fn program_survives_a_call_kind_it_does_not_recognize() {
     let decoded = UnsupportedCallKind::try_from_slice(&event.data).unwrap();
     assert_eq!(decoded.raw_discriminant, 77);
 }
+
+/// A guest that halts with a non-zero code is rejected, but unlike a panic the session survives:
+/// the error carries the metered cycles so the caller can charge them.
+#[test]
+fn nonzero_exit_is_rejected_with_its_cycles() {
+    let program = crate::test_methods::exits_nonzero();
+    let err = program
+        .execute(
+            AccountId::from(program.id()),
+            None,
+            &[],
+            &Vec::new(),
+            DEFAULT_PUBLIC_CYCLE_BUDGET,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, LeeError::ProgramExitedWithCode { code: 3, cycles } if cycles > 0),
+        "expected ProgramExitedWithCode {{ code: 3, cycles > 0 }}, got: {err:?}"
+    );
+}

--- a/lee/state_machine/src/state/tests/mod.rs
+++ b/lee/state_machine/src/state/tests/mod.rs
@@ -60,6 +60,7 @@ impl V03State {
         self.insert_program(&crate::test_methods::private_pda_delegator());
         self.insert_program(&crate::test_methods::noop());
         self.insert_program(&crate::test_methods::chain_caller());
+        self.insert_program(&crate::test_methods::exits_nonzero());
         self.insert_program(&crate::test_methods::non_delegating_forwarder());
         self.insert_program(&crate::test_methods::event_emitter());
         self.insert_program(&crate::test_methods::validity_window());

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -151,10 +151,14 @@ impl ValidatedStateDiff {
             cycle_budget,
             &mut cycles_used,
         );
-        // A panic or session-limit bail loses the count and pays the full budget; a non-zero
-        // exit code is metered like a success.
+        // A non-zero exit keeps its count: the failing call's cycles ride on the error since
+        // `execute_authorized` bailed before adding them. A panic or session-limit bail loses
+        // the count and pays the full budget.
         let cycles = match &result {
-            Ok(_) | Err(LeeError::ProgramExitedWithCode { .. }) => cycles_used,
+            Ok(_) => cycles_used,
+            Err(LeeError::ProgramExitedWithCode { cycles, .. }) => {
+                cycles_used.saturating_add(*cycles)
+            }
             Err(_) => cycle_budget,
         };
         let diff = match result {
@@ -359,22 +363,13 @@ impl ValidatedStateDiff {
                     });
                 };
                 let program = Program::new_unchecked(program_id, Cow::Owned(elf));
-                let (program_output, call_cycles) = match program.execute(
+                let (program_output, call_cycles) = program.execute(
                     chained_call.program_account_id,
                     caller_data.account_id,
                     &real_pre_states,
                     &chained_call.instruction_data,
                     cycle_budget.saturating_sub(*cycles_used),
-                ) {
-                    Ok(ok) => ok,
-                    Err(err) => {
-                        // if there is a non-zero halt, we should charge up to the cycle
-                        if let LeeError::ProgramExitedWithCode { cycles, .. } = err {
-                            *cycles_used = cycles_used.saturating_add(cycles);
-                        }
-                        return Err(err);
-                    }
-                };
+                )?;
                 *cycles_used = cycles_used
                     .checked_add(call_cycles)
                     .expect("cycle sums fit u64: overflow would need ~2^64 executed cycles");

--- a/lee/state_machine/src/validated_state_diff/mod.rs
+++ b/lee/state_machine/src/validated_state_diff/mod.rs
@@ -151,11 +151,11 @@ impl ValidatedStateDiff {
             cycle_budget,
             &mut cycles_used,
         );
-        // any failure pays the full declared budget
-        let cycles = if result.is_err() {
-            cycle_budget
-        } else {
-            cycles_used
+        // A panic or session-limit bail loses the count and pays the full budget; a non-zero
+        // exit code is metered like a success.
+        let cycles = match &result {
+            Ok(_) | Err(LeeError::ProgramExitedWithCode { .. }) => cycles_used,
+            Err(_) => cycle_budget,
         };
         let diff = match result {
             Ok(diff) => diff,
@@ -359,13 +359,22 @@ impl ValidatedStateDiff {
                     });
                 };
                 let program = Program::new_unchecked(program_id, Cow::Owned(elf));
-                let (program_output, call_cycles) = program.execute(
+                let (program_output, call_cycles) = match program.execute(
                     chained_call.program_account_id,
                     caller_data.account_id,
                     &real_pre_states,
                     &chained_call.instruction_data,
                     cycle_budget.saturating_sub(*cycles_used),
-                )?;
+                ) {
+                    Ok(ok) => ok,
+                    Err(err) => {
+                        // if there is a non-zero halt, we should charge up to the cycle
+                        if let LeeError::ProgramExitedWithCode { cycles, .. } = err {
+                            *cycles_used = cycles_used.saturating_add(cycles);
+                        }
+                        return Err(err);
+                    }
+                };
                 *cycles_used = cycles_used
                     .checked_add(call_cycles)
                     .expect("cycle sums fit u64: overflow would need ~2^64 executed cycles");

--- a/lee/state_machine/src/validated_state_diff/tests.rs
+++ b/lee/state_machine/src/validated_state_diff/tests.rs
@@ -297,6 +297,59 @@ fn metered_nonzero_exit_is_charged_its_metered_cycles() {
 }
 
 #[test]
+fn chained_nonzero_exit_adds_callee_cycles_to_callers() {
+    // The accumulation branch only matters once the caller has burned cycles: a chained
+    // callee's non-zero exit must charge caller + callee, not just the callee.
+    let chain_caller = crate::test_methods::chain_caller();
+    let from_key = PrivateKey::try_new([1_u8; 32]).unwrap();
+    let from = AccountId::from(&PublicKey::new_from_private_key(&from_key));
+    let to = AccountId::new([2_u8; 32]);
+    let state = V03State::new()
+        .with_public_accounts(public_state_from_balances(&[(from, 1_000), (to, 0)]))
+        .with_test_programs();
+    let budget = crate::program::DEFAULT_PUBLIC_CYCLE_BUDGET;
+    let run = |num_chain_calls: u32| {
+        let instruction: (
+            u128,
+            lee_core::program::ProgramId,
+            u32,
+            Option<lee_core::program::PdaSeed>,
+        ) = (
+            0,
+            crate::test_methods::exits_nonzero().id(),
+            num_chain_calls,
+            None,
+        );
+        let message = Message::try_new(
+            chain_caller.id().into(),
+            vec![to, from],
+            vec![Nonce(0)],
+            instruction,
+        )
+        .unwrap();
+        let witness_set = WitnessSet::for_message(&message, &[&from_key]);
+        let tx = crate::PublicTransaction::new(message, witness_set);
+        ValidatedStateDiff::from_public_transaction_metered(&tx, &state, 1, 0, budget)
+    };
+
+    let (caller_only, ok) = run(0);
+    ok.expect("the caller alone succeeds");
+
+    let (outcome, result) = run(1);
+    assert!(
+        outcome.cycles > caller_only.cycles && outcome.cycles < budget,
+        "caller + callee cycles are metered: {} vs caller-only {}",
+        outcome.cycles,
+        caller_only.cycles
+    );
+    let diff = result.expect("a charged revert still yields an applicable diff");
+    assert!(
+        diff.public_diff().is_empty(),
+        "a reverted action moves no balances"
+    );
+}
+
+#[test]
 fn metered_revert_reports_cycles_and_yields_a_nonce_only_diff() {
     let (mut state, tx) = metering_transfer_fixture();
     let from = AccountId::from(&PublicKey::new_from_private_key(

--- a/lee/state_machine/src/validated_state_diff/tests.rs
+++ b/lee/state_machine/src/validated_state_diff/tests.rs
@@ -234,9 +234,8 @@ fn free_outcome_is_zero_cycles() {
 #[test]
 fn metered_guest_panic_is_charged_the_full_budget() {
     // A transfer beyond the sender's balance panics the guest mid-execution —
-    // a chargeable failure that is not OutOfGas. It still pays the whole
-    // declared budget: metering written back on an error path must never
-    // undercharge.
+    // a chargeable failure that is not OutOfGas. The panic drops the session
+    // and its count, so it pays the whole declared budget.
     let from_key = PrivateKey::try_new([1_u8; 32]).unwrap();
     let from = AccountId::from(&PublicKey::new_from_private_key(&from_key));
     let to_key = PrivateKey::try_new([2_u8; 32]).unwrap();
@@ -262,7 +261,7 @@ fn metered_guest_panic_is_charged_the_full_budget() {
         ValidatedStateDiff::from_public_transaction_metered(&tx, &state, 1, 0, budget);
     assert_eq!(
         outcome.cycles, budget,
-        "a failed execution pays its full declared budget"
+        "a panic pays its full declared budget"
     );
     result.expect("a charged revert still yields an applicable diff");
 }
@@ -335,12 +334,28 @@ fn chained_nonzero_exit_adds_callee_cycles_to_callers() {
     let (caller_only, ok) = run(0);
     ok.expect("the caller alone succeeds");
 
+    // The callee alone, so the assertion below fails if its cycles are never folded in: a
+    // caller with one chained call burns only marginally more than with none.
+    let callee_message = Message::try_new(
+        crate::test_methods::exits_nonzero().id().into(),
+        vec![from],
+        vec![Nonce(0)],
+        (),
+    )
+    .unwrap();
+    let callee_witness_set = WitnessSet::for_message(&callee_message, &[&from_key]);
+    let callee_tx = crate::PublicTransaction::new(callee_message, callee_witness_set);
+    let (callee_alone, _) =
+        ValidatedStateDiff::from_public_transaction_metered(&callee_tx, &state, 1, 0, budget);
+
     let (outcome, result) = run(1);
     assert!(
-        outcome.cycles > caller_only.cycles && outcome.cycles < budget,
-        "caller + callee cycles are metered: {} vs caller-only {}",
+        outcome.cycles >= caller_only.cycles.saturating_add(callee_alone.cycles)
+            && outcome.cycles < budget,
+        "caller + callee cycles are metered: {} vs caller-only {} + callee-only {}",
         outcome.cycles,
-        caller_only.cycles
+        caller_only.cycles,
+        callee_alone.cycles
     );
     let diff = result.expect("a charged revert still yields an applicable diff");
     assert!(

--- a/lee/state_machine/src/validated_state_diff/tests.rs
+++ b/lee/state_machine/src/validated_state_diff/tests.rs
@@ -268,6 +268,35 @@ fn metered_guest_panic_is_charged_the_full_budget() {
 }
 
 #[test]
+fn metered_nonzero_exit_is_charged_its_metered_cycles() {
+    // Unlike a panic, `env::exit(n)` keeps the session, so the revert pays what
+    // it actually ran rather than the whole budget.
+    let from_key = PrivateKey::try_new([1_u8; 32]).unwrap();
+    let from = AccountId::from(&PublicKey::new_from_private_key(&from_key));
+    let state = V03State::new()
+        .with_public_accounts(public_state_from_balances(&[(from, 100)]))
+        .with_programs(std::iter::once(crate::test_methods::exits_nonzero()));
+    let program_id: AccountId = crate::test_methods::exits_nonzero().id().into();
+    let message = Message::try_new(program_id, vec![from], vec![Nonce(0)], ()).unwrap();
+    let witness_set = WitnessSet::for_message(&message, &[&from_key]);
+    let tx = crate::PublicTransaction::new(message, witness_set);
+
+    let budget = crate::program::DEFAULT_PUBLIC_CYCLE_BUDGET;
+    let (outcome, result) =
+        ValidatedStateDiff::from_public_transaction_metered(&tx, &state, 1, 0, budget);
+    assert!(
+        outcome.cycles > 0 && outcome.cycles < budget,
+        "a non-zero exit is metered, not charged the full budget: {}",
+        outcome.cycles
+    );
+    let diff = result.expect("a charged revert still yields an applicable diff");
+    assert!(
+        diff.public_diff().is_empty(),
+        "a reverted action moves no balances"
+    );
+}
+
+#[test]
 fn metered_revert_reports_cycles_and_yields_a_nonce_only_diff() {
     let (mut state, tx) = metering_transfer_fixture();
     let from = AccountId::from(&PublicKey::new_from_private_key(

--- a/lee/state_machine/test_methods/guest/src/bin/exits_nonzero.rs
+++ b/lee/state_machine/test_methods/guest/src/bin/exits_nonzero.rs
@@ -1,7 +1,7 @@
 use risc0_zkvm::guest::env;
 
-// FIXME: we can remove this program when other guests are re-written
-// andalso handle non-zero codes
+// FIXME: Remove this program once other guests are rewritten
+// to use and handle non-zero exit codes.
 
 fn main() {
     // Commits, then halts with a non-zero code: the host must reject the run but keep the

--- a/lee/state_machine/test_methods/guest/src/bin/exits_nonzero.rs
+++ b/lee/state_machine/test_methods/guest/src/bin/exits_nonzero.rs
@@ -1,0 +1,11 @@
+use risc0_zkvm::guest::env;
+
+// FIXME: we can remove this program when other guests are re-written
+// andalso handle non-zero codes
+
+fn main() {
+    // Commits, then halts with a non-zero code: the host must reject the run but keep the
+    // metered cycle count, unlike a panic which drops the session.
+    env::commit_slice(b"partial");
+    env::exit(3);
+}

--- a/lez/sequencer/core/src/lib.rs
+++ b/lez/sequencer/core/src/lib.rs
@@ -125,8 +125,8 @@ impl DeclaredGasBudget {
     }
 
     /// Snaps the budget to the gas the block's settled transactions were
-    /// actually charged. Failed-but-charged actions pay their full declared
-    /// budget, so the summary never undercounts what replay will enforce.
+    /// actually charged: the metered count for successes and non-zero exits,
+    /// the full declared budget for panics and out-of-gas.
     const fn sync(&mut self, summary: &fee_core::BlockFeeSummary) {
         self.exec = summary.gas_used_exec;
         self.stor = summary.gas_used_stor;


### PR DESCRIPTION
## 🎯 Purpose

A guest that fails via `panic!` bails out of the zkVM executor and drops the session, so the host has no cycle count and charges the full declared budget. A guest that fails via `env::exit(n)` halts normally: the executor keeps the session, the journal, and the metered cycles — but `execute_session` never looked at `exit_code`, so:

- a non-zero halt with a committed journal was **accepted as success** (as was `Paused(_)`);
- a non-zero halt without a journal surfaced as a `malformed program journal frame` failure, with the metered cycles discarded.
- a pause (as in `env::pause` instead of `env::exit`) is treated as a failure and charges the whole budget, because we do not expect multiple tx'es to chain with checkpoints in between, there is no use case for `pause` in LEZ at the time of writing

This PR treats a non-zero exit as a typed, metered revert. It is the host-side prerequisite for rewriting programs to report errors through exit codes instead of panics.

## ⚙️ Approach

- [x] Add `LeeError::ProgramExitedWithCode { code, cycles }` (chargeable, like every post-execution failure).
- [x] `SessionOutcome` carries `exit_code` on both executor paths (r0vm IPC and the in-process `image_cache`).
- [x] `execute_session` gates on it: `Halted(0)` → ok; `Halted(n)` → `ProgramExitedWithCode`; `Paused`/`SystemSplit` → `ProgramExecutionFailed`.
- [x] `execute_authorized` folds a callee's exit-code cycles into `cycles_used` before propagating; `from_public_transaction_metered` charges `cycles_used` for an exit-code revert and still the full budget for panics / session-limit bails.
- [x] Anchor the session-limit match to `root_cause().starts_with("Session limit exceeded:")`. A guest panic always roots at `Guest panicked: …`, so the separate anti-spoof `contains` goes. A typed error is not available: risc0 bails with anyhow and the r0vm IPC boundary flattens errors to a string.

## 🧪 How to Test

```sh
RISC0_DEV_MODE=1 cargo test -p lee --all-features
```

New test guest `exits_nonzero` backs two tests:

- `program::tests::nonzero_exit_is_rejected_with_its_cycles` program exits with the correct error
- `validated_state_diff::tests::metered_nonzero_exit_is_charged_its_metered_cycles` the metered path reports 0 < cycles < budget and a nonce-only diff.

> [!NOTE]
>
> When we later re-write our programs to use non-zero exit codes, we can perhaps get rid of this artificial test.

## 🔗 Dependencies

None

## 🔜 Future Work

- Rewrite programs to fail via `env::exit(code)`; perhaps add a `lee_core` guest-side `abort(code)` helper so programs don't import `risc0_zkvm::guest::env` for this alone.
- Tracker issue opened for `lez-programs`: https://github.com/logos-blockchain/lez-programs/issues/356

## 📋 PR Completion Checklist
- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments