### PR TITLE
fix(nix): fetch risc0 crate from static.crates.io

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
           # Download the crate tarball from crates.io; the checksum from Cargo.lock
           # is the sha256 of the .crate file, so this is a verified fixed-output fetch.
           risc0CircuitRecursionCrate = pkgs.fetchurl {
-            url = "https://crates.io/api/v1/crates/risc0-circuit-recursion/${risc0CircuitRecursion.version}/download";
+            url = "https://static.crates.io/crates/risc0-circuit-recursion/${risc0CircuitRecursion.version}/download";
             sha256 = risc0CircuitRecursion.checksum;
             name = "risc0-circuit-recursion-${risc0CircuitRecursion.version}.crate";
           };


### PR DESCRIPTION
## 🎯 Purpose

Every `packages.*` output currently fails to evaluate: crates.io answers 403 to curl user agents on the `/api/v1/crates/*/download` endpoint ([rust-lang/crates.io#13482](https://github.com/rust-lang/crates.io/issues/13482)). The `risc0-circuit-recursion` fetch in `flake.nix` feeds an IFD that reads the zkr hash out of the crate's `build.rs`, so this breaks evaluation, not just the build.

## ⚙️ Approach

- [x] Fetch the crate from `static.crates.io` instead of the `/api/v1` endpoint.

`sha256` is unchanged — it comes from `Cargo.lock` and the CDN serves byte-identical content.

## 🧪 How to Test

```
nix eval .#packages.x86_64-linux.default.drvPath
```

On `dev` this fails with `error: cannot download risc0-circuit-recursion-4.0.4.crate from any mirror`; with this change it resolves.

## 🔗 Dependencies

None.

## 🔜 Future Work

Downstream consumers pinning an older rev need the same one-line change, or a prefetch of the crate from the CDN as a stopgap.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
