### PR TITLE
refactor(wallet): allow `payer` to be explicitly given

### DIFF
--- a/integration_tests/tests/program_deployment.rs
+++ b/integration_tests/tests/program_deployment.rs
@@ -28,14 +28,20 @@ async fn deploy_and_execute_program() -> Result<()> {
     // account covers the fees instead (see `ProgramLoader::send`).
     let payer_id = ctx.existing_public_accounts()[0];
 
-    // Deploy through `program_loader`: one segment holds the whole (small, test-sized) ELF, then
-    // a header claims it. Both accounts are freshly claimed, permissionless writes.
+    // Deploy through `program_loader`: one segment per ELF chunk, then a header claims the chain.
+    // Every account is freshly claimed, a permissionless write.
     let header_id = new_account(&mut ctx, false, None).await?;
-    let segment_id = new_account(&mut ctx, false, None).await?;
+    let mut segment_ids = Vec::new();
+    for _ in deployed
+        .elf()
+        .chunks(program_loader_core::MAX_SEGMENT_DATA_LEN)
+    {
+        segment_ids.push(new_account(&mut ctx, false, None).await?);
+    }
     let account_id = wallet::program_facades::program_loader::ProgramLoader(ctx.wallet())
         .deploy(
             header_id,
-            &[segment_id],
+            &segment_ids,
             deployed.elf().to_vec(),
             true,
             Some(payer_id),

--- a/integration_tests/tests/program_deployment.rs
+++ b/integration_tests/tests/program_deployment.rs
@@ -20,14 +20,13 @@ use wallet::{
 };
 
 #[test]
-#[ignore = "blocked on fee support for claiming a fresh account under self-pay: the account being \
-            claimed holds nothing to fund the reserve, third-party sponsorship was dropped, and \
-            funding it first auto-claims it through the transfer guest, leaving the claimer nothing \
-            to claim (fee subsystem interim policy)"]
 async fn deploy_and_execute_program() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     let deployed = test_programs::data_writer();
+    // Every account a deploy touches is freshly claimed and unfunded, so a genesis-funded wallet
+    // account covers the fees instead (see `ProgramLoader::send`).
+    let payer_id = ctx.existing_public_accounts()[0];
 
     // Deploy through `program_loader`: one segment holds the whole (small, test-sized) ELF, then
     // a header claims it. Both accounts are freshly claimed, permissionless writes.
@@ -39,29 +38,36 @@ async fn deploy_and_execute_program() -> Result<()> {
             &[segment_id],
             deployed.elf().to_vec(),
             true,
-            None,
+            Some(payer_id),
         )
         .await?;
 
     let target_id = new_account(&mut ctx, false, None).await?;
 
-    let nonces = ctx.wallet_mut().get_accounts_nonces(&[target_id]).await?;
+    // The claimed account holds nothing to fund the reserve with, so `payer_id` co-signs: its
+    // nonce and signature go last, after the account list's own.
+    let nonces = ctx
+        .wallet_mut()
+        .get_accounts_nonces(&[target_id, payer_id])
+        .await?;
     let written: Vec<u8> = vec![9; 4];
-    // Self-pay: the account being claimed is its own fee payer, authorizing with
-    // its own signature. See the `#[ignore]` above — a fresh account holds
-    // nothing to fund the reserve with.
     let message = lee::public_transaction::Message::try_new_with_fees(
         account_id,
         vec![target_id],
         nonces,
         written.clone(),
-        lee::FeeDeclaration::new(target_id, 2_000_000, 0, 100_000_000),
+        common::test_utils::test_fee_declaration(payer_id),
     )?;
-    let private_key = ctx
+    let target_key = ctx
         .wallet()
         .get_account_public_signing_key(target_id)
         .unwrap();
-    let witness_set = lee::public_transaction::WitnessSet::for_message(&message, &[private_key]);
+    let payer_key = ctx
+        .wallet()
+        .get_account_public_signing_key(payer_id)
+        .unwrap();
+    let witness_set =
+        lee::public_transaction::WitnessSet::for_message(&message, &[target_key, payer_key]);
     let transaction = lee::PublicTransaction::new(message, witness_set);
     let _response = ctx
         .sequencer_client()

--- a/integration_tests/tests/wallet_ffi.rs
+++ b/integration_tests/tests/wallet_ffi.rs
@@ -204,6 +204,7 @@ unsafe extern "C" {
         instruction_data: *const u8,
         instruction_data_size: usize,
         program_id: FfiProgramId,
+        payer: *const FfiBytes32,
         out_result: *mut FfiTransactionResult,
     ) -> error::WalletFfiError;
 
@@ -1570,6 +1571,7 @@ fn test_wallet_ffi_transfer_generic_public() -> Result<()> {
             instruction_data_ptr,
             instruction_data_size,
             program_id.into(),
+            std::ptr::null(),
             &raw mut transaction_result,
         )
         .unwrap();

--- a/lez/wallet-ffi/src/generic_transaction.rs
+++ b/lez/wallet-ffi/src/generic_transaction.rs
@@ -137,9 +137,9 @@ impl Default for FfiTransactionResult {
 /// - `account_identities`: Valid pointer to list of `FfiAccountIdentity`
 /// - `instruction_data`: Valid pointer to instruction data bytes
 /// - `payer`: Fee payer, or null to self-pay from the first funded signing account in
-///   `account_identities` (the first signing account if none is funded). May be one of
-///   those signing accounts, or any other public account whose signing key the wallet
-///   holds (it co-signs without joining the account list).
+///   `account_identities` (the first signing account if none is funded). May be one of those
+///   signing accounts, or any other public account whose signing key the wallet holds (it co-signs
+///   without joining the account list).
 /// - `out_result`: Valid pointer to `FfiTransactionResult`
 ///
 /// # Returns

--- a/lez/wallet-ffi/src/generic_transaction.rs
+++ b/lez/wallet-ffi/src/generic_transaction.rs
@@ -11,7 +11,7 @@ use lee::{
 use crate::{
     block_on,
     error::{print_error, WalletFfiError},
-    map_execution_error,
+    map_execution_error, read_optional_account_id,
     wallet::get_wallet,
     FfiAccountIdentity, FfiBytes32, FfiProgramId, WalletHandle,
 };
@@ -136,6 +136,9 @@ impl Default for FfiTransactionResult {
 /// - `handle`: Valid pointer to wallet handle
 /// - `account_identities`: Valid pointer to list of `FfiAccountIdentity`
 /// - `instruction_data`: Valid pointer to instruction data bytes
+/// - `payer`: Fee payer, or null to self-pay from the first funded signing account in
+///   `account_identities`. May be one of those signing accounts, or any other public account whose
+///   signing key the wallet holds (it co-signs without joining the account list)
 /// - `out_result`: Valid pointer to `FfiTransactionResult`
 ///
 /// # Returns
@@ -146,6 +149,7 @@ impl Default for FfiTransactionResult {
 /// - `handle` must be a valid pointer
 /// - `account_identities` must be a valid pointer
 /// - `instruction_data` must be a valid pointer
+/// - `payer` must be null or a valid pointer to a `FfiBytes32`
 /// - `out_result` must be a valid pointer
 #[no_mangle]
 pub unsafe extern "C" fn wallet_ffi_send_generic_public_transaction(
@@ -155,6 +159,7 @@ pub unsafe extern "C" fn wallet_ffi_send_generic_public_transaction(
     instruction_data: *const u8,
     instruction_data_size: usize,
     program_id: FfiProgramId,
+    payer: *const FfiBytes32,
     out_result: *mut FfiTransactionResult,
 ) -> WalletFfiError {
     let wrapper = match get_wallet(handle) {
@@ -200,10 +205,13 @@ pub unsafe extern "C" fn wallet_ffi_send_generic_public_transaction(
         }
     }
 
-    match block_on(wallet.send_pub_tx(
+    let payer = unsafe { read_optional_account_id(payer) };
+
+    match block_on(wallet.send_pub_tx_paid_by(
         accounts,
         instruction_data.to_vec(),
         ProgramId::from(program_id).into(),
+        payer,
     )) {
         Ok(tx_hash) => {
             let tx_hash = CString::new(tx_hash.to_string())

--- a/lez/wallet-ffi/src/generic_transaction.rs
+++ b/lez/wallet-ffi/src/generic_transaction.rs
@@ -137,8 +137,9 @@ impl Default for FfiTransactionResult {
 /// - `account_identities`: Valid pointer to list of `FfiAccountIdentity`
 /// - `instruction_data`: Valid pointer to instruction data bytes
 /// - `payer`: Fee payer, or null to self-pay from the first funded signing account in
-///   `account_identities`. May be one of those signing accounts, or any other public account whose
-///   signing key the wallet holds (it co-signs without joining the account list)
+///   `account_identities` (the first signing account if none is funded). May be one of
+///   those signing accounts, or any other public account whose signing key the wallet
+///   holds (it co-signs without joining the account list).
 /// - `out_result`: Valid pointer to `FfiTransactionResult`
 ///
 /// # Returns

--- a/lez/wallet-ffi/src/lib.rs
+++ b/lez/wallet-ffi/src/lib.rs
@@ -98,6 +98,11 @@ pub(crate) fn map_execution_error(e: ExecutionFailureKind) -> FfiError {
     }
 }
 
+/// Reads a nullable `FfiBytes32` pointer as an optional `AccountId`.
+pub(crate) unsafe fn read_optional_account_id(ptr: *const FfiBytes32) -> Option<lee::AccountId> {
+    (!ptr.is_null()).then(|| lee::AccountId::from(unsafe { *ptr }))
+}
+
 /// Helper to convert a C string to a Rust String.
 fn c_str_to_string(ptr: *const c_char, name: &str) -> Result<String, WalletFfiError> {
     if ptr.is_null() {

--- a/lez/wallet-ffi/src/program_deployment.rs
+++ b/lez/wallet-ffi/src/program_deployment.rs
@@ -7,6 +7,7 @@ use crate::{
     block_on,
     error::{print_error, WalletFfiError},
     generic_transaction::{FfiProgram, FfiTransactionResult},
+    read_optional_account_id,
     wallet::get_wallet,
     FfiBytes32, WalletHandle,
 };
@@ -22,11 +23,6 @@ unsafe fn read_account_ids(data: *const FfiBytes32, len: usize) -> Vec<AccountId
         .iter()
         .map(|bytes| AccountId::from(*bytes))
         .collect()
-}
-
-/// Reads a nullable `FfiBytes32` pointer as an optional `AccountId`.
-unsafe fn read_optional_account_id(ptr: *const FfiBytes32) -> Option<AccountId> {
-    (!ptr.is_null()).then(|| AccountId::from(unsafe { *ptr }))
 }
 
 fn write_result(out_result: *mut FfiTransactionResult, tx_hash: common::HashType) {

--- a/lez/wallet-ffi/src/program_deployment.rs
+++ b/lez/wallet-ffi/src/program_deployment.rs
@@ -24,6 +24,11 @@ unsafe fn read_account_ids(data: *const FfiBytes32, len: usize) -> Vec<AccountId
         .collect()
 }
 
+/// Reads a nullable `FfiBytes32` pointer as an optional `AccountId`.
+unsafe fn read_optional_account_id(ptr: *const FfiBytes32) -> Option<AccountId> {
+    (!ptr.is_null()).then(|| AccountId::from(unsafe { *ptr }))
+}
+
 fn write_result(out_result: *mut FfiTransactionResult, tx_hash: common::HashType) {
     let tx_hash = CString::new(tx_hash.to_string()).map_or(ptr::null_mut(), CString::into_raw);
     unsafe {
@@ -47,6 +52,8 @@ fn write_failure(out_result: *mut FfiTransactionResult) {
 /// - `bytecode_data` must be a valid pointer to `bytecode_size` bytes
 /// - `next_segment` may be null (meaning this is the chain's last segment), otherwise a valid
 ///   pointer to a `FfiBytes32` for an already-uploaded segment
+/// - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+///   to a `FfiBytes32` for a funded account whose signing key the wallet holds
 /// - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
 #[no_mangle]
 pub unsafe extern "C" fn wallet_ffi_program_loader_write_segment(
@@ -55,6 +62,7 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_write_segment(
     bytecode_data: *const u8,
     bytecode_size: usize,
     next_segment: *const FfiBytes32,
+    payer: *const FfiBytes32,
     out_result: *mut FfiTransactionResult,
 ) -> WalletFfiError {
     let wrapper = match get_wallet(handle) {
@@ -75,13 +83,10 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_write_segment(
 
     let target = AccountId::from(unsafe { *target });
     let bytecode = unsafe { read_bytes(bytecode_data, bytecode_size) };
-    let next_segment = if next_segment.is_null() {
-        None
-    } else {
-        Some(AccountId::from(unsafe { *next_segment }))
-    };
+    let next_segment = unsafe { read_optional_account_id(next_segment) };
+    let payer = unsafe { read_optional_account_id(payer) };
 
-    match block_on(ProgramLoader(&wallet).write_segment(target, bytecode, next_segment, None)) {
+    match block_on(ProgramLoader(&wallet).write_segment(target, bytecode, next_segment, payer)) {
         Ok(tx_hash) => {
             write_result(out_result, tx_hash);
             WalletFfiError::Success
@@ -100,6 +105,8 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_write_segment(
 /// - `handle` must be a valid wallet handle from `wallet_ffi_create_new` or `wallet_ffi_open`
 /// - `target` must be a valid pointer to a `FfiBytes32`; the wallet must hold its signing key
 /// - `first_segment` must be a valid pointer to a `FfiBytes32` for an already-uploaded segment
+/// - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+///   to a `FfiBytes32` for a funded account whose signing key the wallet holds
 /// - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
 #[no_mangle]
 pub unsafe extern "C" fn wallet_ffi_program_loader_create_header(
@@ -107,6 +114,7 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_create_header(
     target: *const FfiBytes32,
     first_segment: *const FfiBytes32,
     immutable: bool,
+    payer: *const FfiBytes32,
     out_result: *mut FfiTransactionResult,
 ) -> WalletFfiError {
     let wrapper = match get_wallet(handle) {
@@ -127,6 +135,7 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_create_header(
 
     let target = AccountId::from(unsafe { *target });
     let first_segment = AccountId::from(unsafe { *first_segment });
+    let payer = unsafe { read_optional_account_id(payer) };
 
     let loader = ProgramLoader(&wallet);
     let chain_segment_ids = match block_on(loader.resolve_chain(first_segment)) {
@@ -138,8 +147,13 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_create_header(
         }
     };
 
-    match block_on(loader.create_header(target, first_segment, &chain_segment_ids, immutable, None))
-    {
+    match block_on(loader.create_header(
+        target,
+        first_segment,
+        &chain_segment_ids,
+        immutable,
+        payer,
+    )) {
         Ok(tx_hash) => {
             write_result(out_result, tx_hash);
             WalletFfiError::Success
@@ -160,6 +174,8 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_create_header(
 /// - `header` must be a valid pointer to a `FfiBytes32` for an existing header the wallet is still
 ///   authorized over
 /// - `first_segment` must be a valid pointer to a `FfiBytes32` for an already-uploaded segment
+/// - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+///   to a `FfiBytes32` for a funded account whose signing key the wallet holds
 /// - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
 #[no_mangle]
 pub unsafe extern "C" fn wallet_ffi_program_loader_update_header(
@@ -167,6 +183,7 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_update_header(
     header: *const FfiBytes32,
     first_segment: *const FfiBytes32,
     immutable: bool,
+    payer: *const FfiBytes32,
     out_result: *mut FfiTransactionResult,
 ) -> WalletFfiError {
     let wrapper = match get_wallet(handle) {
@@ -187,6 +204,7 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_update_header(
 
     let header = AccountId::from(unsafe { *header });
     let first_segment = AccountId::from(unsafe { *first_segment });
+    let payer = unsafe { read_optional_account_id(payer) };
 
     let loader = ProgramLoader(&wallet);
     let chain_segment_ids = match block_on(loader.resolve_chain(first_segment)) {
@@ -198,8 +216,13 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_update_header(
         }
     };
 
-    match block_on(loader.update_header(header, first_segment, &chain_segment_ids, immutable, None))
-    {
+    match block_on(loader.update_header(
+        header,
+        first_segment,
+        &chain_segment_ids,
+        immutable,
+        payer,
+    )) {
         Ok(tx_hash) => {
             write_result(out_result, tx_hash);
             WalletFfiError::Success
@@ -224,6 +247,8 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_update_header(
 /// - `segments` must be a valid pointer to `segments_len` contiguous `FfiBytes32`s, in chain order
 ///   (first chunk first); the wallet must hold every segment's signing key
 /// - `elf_data` must be a valid pointer to `elf_size` bytes
+/// - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+///   to a `FfiBytes32` for a funded account whose signing key the wallet holds
 /// - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
 #[no_mangle]
 pub unsafe extern "C" fn wallet_ffi_program_loader_deploy(
@@ -234,6 +259,7 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_deploy(
     elf_data: *const u8,
     elf_size: usize,
     immutable: bool,
+    payer: *const FfiBytes32,
     out_result: *mut FfiTransactionResult,
 ) -> WalletFfiError {
     let wrapper = match get_wallet(handle) {
@@ -255,8 +281,9 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_deploy(
     let header = AccountId::from(unsafe { *header });
     let segment_ids = unsafe { read_account_ids(segments, segments_len) };
     let elf = unsafe { read_bytes(elf_data, elf_size) };
+    let payer = unsafe { read_optional_account_id(payer) };
 
-    match block_on(ProgramLoader(&wallet).deploy(header, &segment_ids, elf, immutable, None)) {
+    match block_on(ProgramLoader(&wallet).deploy(header, &segment_ids, elf, immutable, payer)) {
         Ok(header_account_id) => {
             let tx_hash_str = header_account_id.to_string();
             let tx_hash = CString::new(tx_hash_str).map_or(ptr::null_mut(), CString::into_raw);
@@ -287,6 +314,8 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_deploy(
 /// - `segments` must be a valid pointer to `segments_len` contiguous `FfiBytes32`s, in chain order;
 ///   the wallet must hold every segment's signing key
 /// - `elf_data` must be a valid pointer to `elf_size` bytes
+/// - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+///   to a `FfiBytes32` for a funded account whose signing key the wallet holds
 /// - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
 #[no_mangle]
 pub unsafe extern "C" fn wallet_ffi_program_loader_update(
@@ -297,6 +326,7 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_update(
     elf_data: *const u8,
     elf_size: usize,
     immutable: bool,
+    payer: *const FfiBytes32,
     out_result: *mut FfiTransactionResult,
 ) -> WalletFfiError {
     let wrapper = match get_wallet(handle) {
@@ -318,8 +348,9 @@ pub unsafe extern "C" fn wallet_ffi_program_loader_update(
     let header = AccountId::from(unsafe { *header });
     let segment_ids = unsafe { read_account_ids(segments, segments_len) };
     let elf = unsafe { read_bytes(elf_data, elf_size) };
+    let payer = unsafe { read_optional_account_id(payer) };
 
-    match block_on(ProgramLoader(&wallet).update(header, &segment_ids, elf, immutable, None)) {
+    match block_on(ProgramLoader(&wallet).update(header, &segment_ids, elf, immutable, payer)) {
         Ok(()) => {
             let tx_hash =
                 CString::new(header.to_string()).map_or(ptr::null_mut(), CString::into_raw);

--- a/lez/wallet-ffi/wallet_ffi.h
+++ b/lez/wallet-ffi/wallet_ffi.h
@@ -602,6 +602,9 @@ enum WalletFfiError wallet_ffi_bridge_withdraw(struct WalletHandle *handle,
  * - `handle`: Valid pointer to wallet handle
  * - `account_identities`: Valid pointer to list of `FfiAccountIdentity`
  * - `instruction_data`: Valid pointer to instruction data bytes
+ * - `payer`: Fee payer, or null to self-pay from the first funded signing account in
+ *   `account_identities`. May be one of those signing accounts, or any other public account whose
+ *   signing key the wallet holds (it co-signs without joining the account list)
  * - `out_result`: Valid pointer to `FfiTransactionResult`
  *
  * # Returns
@@ -612,6 +615,7 @@ enum WalletFfiError wallet_ffi_bridge_withdraw(struct WalletHandle *handle,
  * - `handle` must be a valid pointer
  * - `account_identities` must be a valid pointer
  * - `instruction_data` must be a valid pointer
+ * - `payer` must be null or a valid pointer to a `FfiBytes32`
  * - `out_result` must be a valid pointer
  */
 enum WalletFfiError wallet_ffi_send_generic_public_transaction(struct WalletHandle *handle,
@@ -620,6 +624,7 @@ enum WalletFfiError wallet_ffi_send_generic_public_transaction(struct WalletHand
                                                                const uint8_t *instruction_data,
                                                                uintptr_t instruction_data_size,
                                                                struct FfiProgramId program_id,
+                                                               const struct FfiBytes32 *payer,
                                                                struct FfiTransactionResult *out_result);
 
 /**

--- a/lez/wallet-ffi/wallet_ffi.h
+++ b/lez/wallet-ffi/wallet_ffi.h
@@ -603,9 +603,9 @@ enum WalletFfiError wallet_ffi_bridge_withdraw(struct WalletHandle *handle,
  * - `account_identities`: Valid pointer to list of `FfiAccountIdentity`
  * - `instruction_data`: Valid pointer to instruction data bytes
  * - `payer`: Fee payer, or null to self-pay from the first funded signing account in
- *   `account_identities` (the first signing account if none is funded). May be one of
- *   those signing accounts, or any other public account whose signing key the wallet
- *   holds (it co-signs without joining the account list).
+ *   `account_identities` (the first signing account if none is funded). May be one of those
+ *   signing accounts, or any other public account whose signing key the wallet holds (it co-signs
+ *   without joining the account list).
  * - `out_result`: Valid pointer to `FfiTransactionResult`
  *
  * # Returns

--- a/lez/wallet-ffi/wallet_ffi.h
+++ b/lez/wallet-ffi/wallet_ffi.h
@@ -962,6 +962,8 @@ enum WalletFfiError wallet_ffi_account_id_for_private_pda(struct FfiProgramId pr
  * - `bytecode_data` must be a valid pointer to `bytecode_size` bytes
  * - `next_segment` may be null (meaning this is the chain's last segment), otherwise a valid
  *   pointer to a `FfiBytes32` for an already-uploaded segment
+ * - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+ *   to a `FfiBytes32` for a funded account whose signing key the wallet holds
  * - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
  */
 enum WalletFfiError wallet_ffi_program_loader_write_segment(struct WalletHandle *handle,
@@ -969,6 +971,7 @@ enum WalletFfiError wallet_ffi_program_loader_write_segment(struct WalletHandle 
                                                             const uint8_t *bytecode_data,
                                                             uintptr_t bytecode_size,
                                                             const struct FfiBytes32 *next_segment,
+                                                            const struct FfiBytes32 *payer,
                                                             struct FfiTransactionResult *out_result);
 
 /**
@@ -978,12 +981,15 @@ enum WalletFfiError wallet_ffi_program_loader_write_segment(struct WalletHandle 
  * - `handle` must be a valid wallet handle from `wallet_ffi_create_new` or `wallet_ffi_open`
  * - `target` must be a valid pointer to a `FfiBytes32`; the wallet must hold its signing key
  * - `first_segment` must be a valid pointer to a `FfiBytes32` for an already-uploaded segment
+ * - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+ *   to a `FfiBytes32` for a funded account whose signing key the wallet holds
  * - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
  */
 enum WalletFfiError wallet_ffi_program_loader_create_header(struct WalletHandle *handle,
                                                             const struct FfiBytes32 *target,
                                                             const struct FfiBytes32 *first_segment,
                                                             bool immutable,
+                                                            const struct FfiBytes32 *payer,
                                                             struct FfiTransactionResult *out_result);
 
 /**
@@ -995,12 +1001,15 @@ enum WalletFfiError wallet_ffi_program_loader_create_header(struct WalletHandle 
  * - `header` must be a valid pointer to a `FfiBytes32` for an existing header the wallet is still
  *   authorized over
  * - `first_segment` must be a valid pointer to a `FfiBytes32` for an already-uploaded segment
+ * - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+ *   to a `FfiBytes32` for a funded account whose signing key the wallet holds
  * - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
  */
 enum WalletFfiError wallet_ffi_program_loader_update_header(struct WalletHandle *handle,
                                                             const struct FfiBytes32 *header,
                                                             const struct FfiBytes32 *first_segment,
                                                             bool immutable,
+                                                            const struct FfiBytes32 *payer,
                                                             struct FfiTransactionResult *out_result);
 
 /**
@@ -1016,6 +1025,8 @@ enum WalletFfiError wallet_ffi_program_loader_update_header(struct WalletHandle 
  * - `segments` must be a valid pointer to `segments_len` contiguous `FfiBytes32`s, in chain order
  *   (first chunk first); the wallet must hold every segment's signing key
  * - `elf_data` must be a valid pointer to `elf_size` bytes
+ * - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+ *   to a `FfiBytes32` for a funded account whose signing key the wallet holds
  * - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
  */
 enum WalletFfiError wallet_ffi_program_loader_deploy(struct WalletHandle *handle,
@@ -1025,6 +1036,7 @@ enum WalletFfiError wallet_ffi_program_loader_deploy(struct WalletHandle *handle
                                                      const uint8_t *elf_data,
                                                      uintptr_t elf_size,
                                                      bool immutable,
+                                                     const struct FfiBytes32 *payer,
                                                      struct FfiTransactionResult *out_result);
 
 /**
@@ -1041,6 +1053,8 @@ enum WalletFfiError wallet_ffi_program_loader_deploy(struct WalletHandle *handle
  * - `segments` must be a valid pointer to `segments_len` contiguous `FfiBytes32`s, in chain order;
  *   the wallet must hold every segment's signing key
  * - `elf_data` must be a valid pointer to `elf_size` bytes
+ * - `payer` may be null (self-pay from the transaction's own accounts), otherwise a valid pointer
+ *   to a `FfiBytes32` for a funded account whose signing key the wallet holds
  * - `out_result` must be a valid pointer to a `FfiTransactionResult` struct
  */
 enum WalletFfiError wallet_ffi_program_loader_update(struct WalletHandle *handle,
@@ -1050,6 +1064,7 @@ enum WalletFfiError wallet_ffi_program_loader_update(struct WalletHandle *handle
                                                      const uint8_t *elf_data,
                                                      uintptr_t elf_size,
                                                      bool immutable,
+                                                     const struct FfiBytes32 *payer,
                                                      struct FfiTransactionResult *out_result);
 
 /**

--- a/lez/wallet-ffi/wallet_ffi.h
+++ b/lez/wallet-ffi/wallet_ffi.h
@@ -603,8 +603,9 @@ enum WalletFfiError wallet_ffi_bridge_withdraw(struct WalletHandle *handle,
  * - `account_identities`: Valid pointer to list of `FfiAccountIdentity`
  * - `instruction_data`: Valid pointer to instruction data bytes
  * - `payer`: Fee payer, or null to self-pay from the first funded signing account in
- *   `account_identities`. May be one of those signing accounts, or any other public account whose
- *   signing key the wallet holds (it co-signs without joining the account list)
+ *   `account_identities` (the first signing account if none is funded). May be one of
+ *   those signing accounts, or any other public account whose signing key the wallet
+ *   holds (it co-signs without joining the account list).
  * - `out_result`: Valid pointer to `FfiTransactionResult`
  *
  * # Returns

--- a/lez/wallet/src/account_manager.rs
+++ b/lez/wallet/src/account_manager.rs
@@ -473,6 +473,18 @@ impl AccountManager {
             .map(|account| account.account_id)
     }
 
+    /// Whether `account_id` is a public account whose signature [`Self::sign_message`] produces.
+    pub fn signs_for(&self, account_id: AccountId) -> bool {
+        self.states.iter().any(|state| match state {
+            State::Public {
+                account,
+                sk: Some(_),
+            }
+            | State::PublicKeycard { account, .. } => account.account_id == account_id,
+            State::Public { sk: None, .. } | State::Private(_) => false,
+        })
+    }
+
     pub fn public_account_ids(&self) -> Vec<AccountId> {
         self.states
             .iter()
@@ -845,6 +857,19 @@ mod tests {
         let first_id = account.account_id;
         let manager = manager(vec![first, public_signing_state(8, 0)]);
         assert_eq!(manager.fee_payer_account_id(), Some(first_id));
+    }
+
+    #[test]
+    fn signs_for_only_signing_public_accounts() {
+        let signing = public_signing_state(9, 0);
+        let State::Public { account, .. } = &signing else {
+            unreachable!("public_signing_state builds a public account");
+        };
+        let signing_id = account.account_id;
+        let manager = manager(vec![public_state(), signing]);
+        let non_signing_id = manager.public_account_ids()[0];
+        assert!(manager.signs_for(signing_id));
+        assert!(!manager.signs_for(non_signing_id));
     }
 
     #[test]

--- a/lez/wallet/src/lib.rs
+++ b/lez/wallet/src/lib.rs
@@ -876,12 +876,14 @@ impl WalletCore {
 
     /// Sends a public transaction over `accounts`, paid by `payer` if given.
     ///
-    /// `payer: None` picks the first funded signing account in `accounts`. An explicit payer may
-    /// be one of `accounts`' signing entries, or any other public account whose signing key the
-    /// wallet holds: the latter co-signs (nonce and signature appended after `accounts`' own)
-    /// without joining the message's `account_ids`, so programs with a fixed account shape — e.g.
-    /// `program_loader`, whose accounts are all freshly claimed and unfunded — can still be paid
-    /// for.
+    /// `payer: None` picks the first funded signing account in `accounts`, or the first signing
+    /// account if none is funded (see [`AccountManager::fee_payer_account_id`]).
+    ///
+    /// An explicit payer may be one of `accounts`' signing entries, or any other public account
+    /// whose signing key the wallet holds: the latter co-signs (nonce and signature appended
+    /// after `accounts`' own) without joining the message's `account_ids`, so programs with a
+    /// fixed account shape (like the `program_loader`, whose accounts are all freshly claimed
+    /// and unfunded) can still be paid for.
     pub async fn send_pub_tx_with_pre_check(
         &self,
         accounts: Vec<AccountIdentity>,

--- a/lez/wallet/src/lib.rs
+++ b/lez/wallet/src/lib.rs
@@ -851,15 +851,43 @@ impl WalletCore {
         instruction_data: InstructionData,
         program_account_id: AccountId,
     ) -> Result<HashType, ExecutionFailureKind> {
-        self.send_pub_tx_with_pre_check(accounts, instruction_data, program_account_id, |_| Ok(()))
+        self.send_pub_tx_paid_by(accounts, instruction_data, program_account_id, None)
             .await
     }
 
+    /// Like [`Self::send_pub_tx`], but `payer` (if given) covers the fee instead of the wallet's
+    /// self-pay selection. See [`Self::send_pub_tx_with_pre_check`].
+    pub async fn send_pub_tx_paid_by(
+        &self,
+        accounts: Vec<AccountIdentity>,
+        instruction_data: InstructionData,
+        program_account_id: AccountId,
+        payer: Option<AccountId>,
+    ) -> Result<HashType, ExecutionFailureKind> {
+        self.send_pub_tx_with_pre_check(
+            accounts,
+            instruction_data,
+            program_account_id,
+            payer,
+            |_| Ok(()),
+        )
+        .await
+    }
+
+    /// Sends a public transaction over `accounts`, paid by `payer` if given.
+    ///
+    /// `payer: None` picks the first funded signing account in `accounts`. An explicit payer may
+    /// be one of `accounts`' signing entries, or any other public account whose signing key the
+    /// wallet holds: the latter co-signs (nonce and signature appended after `accounts`' own)
+    /// without joining the message's `account_ids`, so programs with a fixed account shape — e.g.
+    /// `program_loader`, whose accounts are all freshly claimed and unfunded — can still be paid
+    /// for.
     pub async fn send_pub_tx_with_pre_check(
         &self,
         accounts: Vec<AccountIdentity>,
         instruction_data: InstructionData,
         program_account_id: AccountId,
+        payer: Option<AccountId>,
         tx_pre_check: impl FnOnce(&[&Account]) -> Result<(), ExecutionFailureKind>,
     ) -> Result<HashType, ExecutionFailureKind> {
         // Public transaction, all accounts must be public
@@ -882,13 +910,38 @@ impl WalletCore {
         )?;
 
         let account_ids = acc_manager.public_account_ids();
-        let nonces = acc_manager.public_account_nonces();
+        let mut nonces = acc_manager.public_account_nonces();
 
-        let payer = acc_manager.fee_payer_account_id().ok_or_else(|| {
+        let invalid_input = |msg: &str| {
             ExecutionFailureKind::TransactionBuildError(lee::error::LeeError::InvalidInput(
-                "Public transaction has no signing account to pay its fees".to_owned(),
+                msg.to_owned(),
             ))
-        })?;
+        };
+        let (payer, co_signer) = match payer {
+            None => (
+                acc_manager.fee_payer_account_id().ok_or_else(|| {
+                    invalid_input("Public transaction has no signing account to pay its fees")
+                })?,
+                None,
+            ),
+            Some(payer) if acc_manager.signs_for(payer) => (payer, None),
+            Some(payer) if account_ids.contains(&payer) => {
+                return Err(invalid_input(
+                    "Fee payer is a non-signing account of this transaction",
+                ));
+            }
+            Some(payer) => {
+                let key = self.get_account_public_signing_key(payer).ok_or_else(|| {
+                    invalid_input("Fee payer's signing key is not held by this wallet")
+                })?;
+                let account = self
+                    .get_account_public(payer)
+                    .await
+                    .map_err(ExecutionFailureKind::SequencerError)?;
+                nonces.push(account.nonce);
+                (payer, Some(key))
+            }
+        };
 
         let message = lee::public_transaction::Message::new_preserialized(
             program_account_id,
@@ -904,29 +957,21 @@ impl WalletCore {
         );
 
         let message_hash = message.hash();
-        let signatures_public_keys = acc_manager
+        let mut signatures_public_keys = acc_manager
             .sign_message(message_hash)
             .map_err(ExecutionFailureKind::SignError)?;
+        if let Some(key) = co_signer {
+            signatures_public_keys.push((
+                lee::Signature::new(key, &message_hash),
+                lee::PublicKey::new_from_private_key(key),
+            ));
+        }
 
         let witness_set =
             lee::public_transaction::WitnessSet::from_raw_parts(signatures_public_keys);
 
         let tx = lee::public_transaction::PublicTransaction::new(message, witness_set);
 
-        first_success_or_error(
-            self.multi_sequencer_client
-                .metered_send_transaction(LeeTransaction::Public(tx))
-                .await,
-        )
-    }
-
-    /// Submits an already-built public transaction directly, for callers that need to construct
-    /// their own [`FeeDeclaration`] (e.g. a facade taking a separate fee payer) instead of going
-    /// through [`Self::send_pub_tx`]'s self-pay selection.
-    pub(crate) async fn submit_public_transaction(
-        &self,
-        tx: lee::public_transaction::PublicTransaction,
-    ) -> Result<HashType, ExecutionFailureKind> {
         first_success_or_error(
             self.multi_sequencer_client
                 .metered_send_transaction(LeeTransaction::Public(tx))

--- a/lez/wallet/src/program_facades/native_token_transfer/public.rs
+++ b/lez/wallet/src/program_facades/native_token_transfer/public.rs
@@ -20,6 +20,7 @@ impl NativeTokenTransfer<'_> {
                 vec![from, to],
                 instruction_data,
                 program.id().into(),
+                None,
                 tx_pre_check,
             )
             .await

--- a/lez/wallet/src/program_facades/program_loader.rs
+++ b/lez/wallet/src/program_facades/program_loader.rs
@@ -1,13 +1,10 @@
 use anyhow::{Context as _, Result, bail};
 use common::HashType;
-use lee::{AccountId, PublicKey, Signature, program::Program};
+use lee::{AccountId, program::Program};
 use lee_core::program::PROGRAM_LOADER_ACCOUNT_ID;
 use program_loader_core::{Instruction, MAX_PROGRAM_SEGMENTS, MAX_SEGMENT_DATA_LEN};
 
-use crate::{
-    AccountIdentity, DEFAULT_GAS_LIMIT, DEFAULT_MAX_FEE, ExecutionFailureKind, WalletCore,
-    account_manager::AccountManager,
-};
+use crate::{AccountIdentity, ExecutionFailureKind, WalletCore};
 
 /// Facade for `program_loader`'s `WriteSegment`/`CreateHeader`/`UpdateHeader` instructions.
 ///
@@ -19,84 +16,19 @@ pub struct ProgramLoader<'wallet>(pub &'wallet WalletCore);
 impl ProgramLoader<'_> {
     /// Sends a `program_loader` instruction over `accounts`, paid by `payer` if given.
     ///
-    /// `accounts`' own accounts are always freshly claimed here — unlike, say, a transfer (whose
-    /// account list always includes an existing, funded sender), a deploy's account list holds
-    /// nothing but the brand-new accounts it is claiming, so there is never a funded account for
-    /// the wallet's ordinary self-pay selection to find. `payer` names a separately-funded account
-    /// to cover the fee instead: it co-signs and gets its own nonce entry, but — unlike
-    /// `accounts` — is never added to the message's `account_ids`, since `program_loader`
-    /// requires an exact account count/shape per instruction and an extra trailing account
-    /// would break that. `payer: None` falls back to the wallet's ordinary self-pay selection via
-    /// [`WalletCore::send_pub_tx`], unchanged from before fees existed — every existing caller
-    /// (the FFI bindings) still gets that behavior.
+    /// A deploy's account list holds nothing but the brand-new accounts it is claiming, so there
+    /// is never a funded account for self-pay to find: `payer` names a separately-funded account
+    /// that co-signs without joining the instruction's account list (see
+    /// [`WalletCore::send_pub_tx_with_pre_check`]).
     async fn send(
         &self,
         accounts: Vec<AccountIdentity>,
         instruction_data: lee_core::program::InstructionData,
         payer: Option<AccountId>,
     ) -> Result<HashType, ExecutionFailureKind> {
-        let Some(payer) = payer else {
-            return self
-                .0
-                .send_pub_tx(accounts, instruction_data, PROGRAM_LOADER_ACCOUNT_ID)
-                .await;
-        };
-
-        if accounts.iter().any(AccountIdentity::is_private) {
-            return Err(ExecutionFailureKind::TransactionBuildError(
-                lee::error::LeeError::InvalidInput(
-                    "Private accounts are not allowed in public transactions".to_owned(),
-                ),
-            ));
-        }
-
-        let acc_manager = AccountManager::new(self.0, accounts).await?;
-        let account_ids = acc_manager.public_account_ids();
-        let mut nonces = acc_manager.public_account_nonces();
-
-        let payer_account = self
-            .0
-            .get_account_public(payer)
+        self.0
+            .send_pub_tx_paid_by(accounts, instruction_data, PROGRAM_LOADER_ACCOUNT_ID, payer)
             .await
-            .map_err(ExecutionFailureKind::SequencerError)?;
-        let payer_key = self
-            .0
-            .get_account_public_signing_key(payer)
-            .ok_or_else(|| {
-                ExecutionFailureKind::TransactionBuildError(lee::error::LeeError::InvalidInput(
-                    "Fee payer's signing key is not held by this wallet".to_owned(),
-                ))
-            })?;
-        // Appended last, after every regular signer `sign_message` produces — nonces and
-        // signatures must line up positionally (see `AccountManager::public_account_nonces`).
-        nonces.push(payer_account.nonce);
-
-        let message = lee::public_transaction::Message::new_preserialized(
-            PROGRAM_LOADER_ACCOUNT_ID,
-            account_ids,
-            nonces,
-            instruction_data,
-            Some(lee::FeeDeclaration::new(
-                payer,
-                DEFAULT_GAS_LIMIT,
-                0,
-                DEFAULT_MAX_FEE,
-            )),
-        );
-
-        let message_hash = message.hash();
-        let mut signatures_public_keys = acc_manager
-            .sign_message(message_hash)
-            .map_err(ExecutionFailureKind::SignError)?;
-        signatures_public_keys.push((
-            Signature::new(payer_key, &message_hash),
-            PublicKey::new_from_private_key(payer_key),
-        ));
-        let witness_set =
-            lee::public_transaction::WitnessSet::from_raw_parts(signatures_public_keys);
-
-        let tx = lee::public_transaction::PublicTransaction::new(message, witness_set);
-        self.0.submit_public_transaction(tx).await
     }
 
     /// Writes one bytecode segment at `target` (must already be a default/unclaimed account,


### PR DESCRIPTION
## 🎯 Purpose

`wallet_ffi_program_loader_*` entry point passed `payer: None`, so a deploy through the FFI could not be admitted on a fee-enabled sequencer.

Self-pay selection only looks at the transaction's own accounts, and a `program_loader` instruction's accounts are all fresh and unfunded. The sequencer rejects with `PayerCannotFund`. The CLI and the Rust facade already took an explicit `payer`; the FFI did not wire it through.

Underneath that, the wallet had two ways to build a fee declaration: `send_pub_tx` (first funded signer in the account list pays) and a hand-rolled co-signing path inside `ProgramLoader::send` for the one program that needed a payer outside its account list. The self-pay fee plan kept explicit payer designation and only dropped *non-signing* third-party sponsorship, so a co-signing payer is protocol-legal for every public tx (`lee::fees::is_fee_authorized` scans the witness set for the payer's signature). The wallet never generalized it.

Closes #839.

## ⚙️ Approach

**`wallet`: explicit payer on the shared public-tx path**

- [x] `send_pub_tx_with_pre_check` takes `payer: Option<AccountId>` and resolves it in one place:
  - `None` — today's heuristic (first funded signing account in the list).
  - payer is a signing account of the tx — used as-is; its ordinary signature authorizes the fee.
  - payer is outside the tx — co-signs: its nonce and signature are appended after the list's own, and it is *not* added to `account_ids`, so programs with a fixed account shape keep working.
  - payer is in the tx but non-signing (`PublicNoSign`) — rejected with a clear error; nonces pair one-to-one with signatures, so a duplicate signer is not representable.
- [x] Add `send_pub_tx_paid_by(accounts, data, program, payer)`; `send_pub_tx` stays as the `None` wrapper so existing callers are untouched.
- [x] Add `AccountManager::signs_for(account_id)` helper.
- [x] Collapse `ProgramLoader::send` onto `send_pub_tx_paid_by`; delete `submit_public_transaction`.

**`wallet-ffi`: nullable `payer` on the five `program_loader` functions**

- [x] `wallet_ffi_program_loader_{write_segment, create_header, update_header, deploy, update}` gain `const struct FfiBytes32 *payer` before `out_result`. `NULL` keeps the self-pay fallback (which still fails for deploys, as documented).
- [x] Add `read_optional_account_id` helper, replacing the inline `next_segment` null check.
- [x] `wallet_ffi_send_generic_public_transaction` gains the same nullable `payer`, so the wallet UI can name a payer for any public transaction, not just deploys.
- [x] Regenerate `wallet_ffi.h`.

**Tests**

- [x] Un-ignore `deploy_and_execute_program`: deploys with the genesis-funded wallet account as payer, and the follow-up write to a fresh account has the same payer co-sign.
- [x] Fix the test's segment setup: segment accounts are sized from the ELF's chunk count instead of assuming one segment.
- [x] Unit test for `signs_for`.

**Breaking (FFI ABI):** the five `wallet_ffi_program_loader_*` signatures change. `logos-execution-zone-module` calls them in `src/lez_core_module.{h,cpp}` and its test stubs/mocks; each call needs the extra argument when it bumps its LEZ input.

## 🧪 How to Test

```sh
RISC0_DEV_MODE=1 cargo test -p integration_tests --test program_deployment
RISC0_DEV_MODE=1 cargo test -p wallet signs_for
cargo +nightly fmt --check
cargo clippy -p wallet -p wallet-ffi --all-targets -- -D warnings
```

`deploy_and_execute_program` was `#[ignore]`d before this PR and now passes.

## 🔗 Dependencies

None.

## 🔜 Future Work

- Fee declaration parameters (`gas_limit`/`tip`/`max_fee`) are still the wallet's fixed defaults — #842 opened for that.
- `logos-execution-zone-module` call-site bump for the new FFI argument (and the related Wallet UI updates)

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments