### PR TITLE
chore(lez): add logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid 0.10.2",
  "zeroize",
@@ -2898,7 +2898,7 @@ version = "0.17.0-rc.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
  "digest 0.11.3",
  "elliptic-curve 0.14.0",
  "rfc6979 0.6.0-pre.0",
@@ -9225,7 +9225,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
  "spki 0.8.0",
 ]
 
@@ -11045,7 +11045,7 @@ checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct 1.0.0",
  "ctutils",
- "der 0.8.0",
+ "der 0.8.2",
  "hybrid-array",
  "subtle",
  "zeroize",
@@ -11865,7 +11865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.0",
+ "der 0.8.2",
 ]
 
 [[package]]

--- a/lez/sequencer/core/src/block_publisher.rs
+++ b/lez/sequencer/core/src/block_publisher.rs
@@ -444,13 +444,12 @@ impl BlockPublisherTrait for ZoneSdkPublisher {
                                     let adopted = channel_update
                                         .adopted
                                         .iter()
-                                        .flat_map(|tx| adopted_blocks(tx, channel_id))
+                                        .flat_map(|tx| channel_blocks(tx, channel_id))
                                         .collect();
                                     let orphaned = channel_update
                                         .orphaned
                                         .iter()
-                                        .filter_map(channel_update_inscription)
-                                        .filter_map(block_from_inscription)
+                                        .flat_map(|tx| channel_blocks(tx, channel_id))
                                         .collect();
 
                                     let mut finalized_blocks = Vec::new();
@@ -759,9 +758,10 @@ fn block_from_inscription(inscription: &InscriptionInfo) -> Option<Block> {
         .ok()
 }
 
-/// Every block an adopted tx carries, in op order. Non-block entries are
-/// dropped: they reach consumers as the checkpoint's tip, not as payloads.
-fn adopted_blocks(tx: &ChannelUpdateTx, channel_id: ChannelId) -> Vec<Block> {
+/// Every block a channel tx carries, in op order.
+///
+/// A config op is on the config lineage, not this one, so it is skipped.
+pub(crate) fn channel_blocks(tx: &ChannelUpdateTx, channel_id: ChannelId) -> Vec<Block> {
     let entry = |inscription: &InscriptionInfo| {
         if <Inscription as AsRef<[u8]>>::as_ref(&inscription.payload).is_empty() {
             None
@@ -772,7 +772,6 @@ fn adopted_blocks(tx: &ChannelUpdateTx, channel_id: ChannelId) -> Vec<Block> {
     match tx {
         ChannelUpdateTx::Inscription(info) => entry(info).into_iter().collect(),
         ChannelUpdateTx::AtomicWithdraw(bundle) => entry(&bundle.inscription).into_iter().collect(),
-        // A config-only tx carries no payload to apply.
         ChannelUpdateTx::Config(_) => Vec::new(),
         ChannelUpdateTx::Custom(signed_tx) => channel_inscriptions(signed_tx, channel_id)
             .iter()
@@ -791,15 +790,6 @@ fn released_notes(tx: &PendingTx) -> Vec<NoteId> {
             .iter()
             .flat_map(|withdraw| withdraw.op.inputs.iter().copied())
             .collect(),
-    }
-}
-
-/// The inscription carried by an orphaned tx (plain or atomic-withdraw bundle).
-const fn channel_update_inscription(orphan: &ChannelUpdateTx) -> Option<&InscriptionInfo> {
-    match orphan {
-        ChannelUpdateTx::Inscription(info) => Some(info),
-        ChannelUpdateTx::AtomicWithdraw(bundle) => Some(&bundle.inscription),
-        ChannelUpdateTx::Config(_) | ChannelUpdateTx::Custom(_) => None,
     }
 }
 

--- a/lez/sequencer/core/src/lib.rs
+++ b/lez/sequencer/core/src/lib.rs
@@ -47,6 +47,7 @@ use tokio_retry::{Retry, strategy::FixedInterval};
 use crate::{
     block_publisher::{BlockPublisherTrait, MsgId, NoteId, ZoneSdkPublisher},
     block_store::SequencerStore,
+    logging::{log_high_water_lowered, log_parked, log_rewind, log_update, pin_str},
     task_group::TaskGroup,
 };
 
@@ -57,6 +58,7 @@ pub mod config;
 pub mod cross_zone_watcher;
 pub mod fees;
 pub mod gossip;
+pub mod logging;
 #[cfg(feature = "mock")]
 pub mod mock;
 pub mod slashing;
@@ -801,6 +803,15 @@ impl<S: StorageActorTrait, BP: BlockPublisherTrait> SequencerCore<S, BP> {
             .build_block_from_mempool(live_committee.as_ref())
             .await
             .context("Failed to build block from mempool transactions")?;
+
+        // Height and pin together: the height comes from the head and the pin
+        // from the cursor, and only this line records what they were as a pair.
+        // Bundled withdrawals take the unpinned path, where the sdk picks the parent.
+        info!(
+            "Publishing block {} on pin {}",
+            block.header.block_id,
+            pin_str(parent.filter(|_| withdrawals.is_empty())),
+        );
 
         let block_publisher::PublishOutcome {
             this_msg,
@@ -1894,23 +1905,8 @@ async fn apply_follow_update<S: StorageActorTrait>(
     let (resubmit_txs, outcome, head_height) = {
         let mut chain = chain.lock().await;
 
-        // An orphan report rewinds the head to the earliest orphaned block and
-        // prunes the store above it, which is how a run of our own inscriptions
-        // can silently stop being ours. Loud on the way in: it is the only
-        // trace, and the rewind it causes is the expensive one.
-        // Debug, not warn: the sdk orphans our blocks routinely once LIB pruning
-        // drops them from the lineage, and most of those no longer sit in the
-        // head. The rewind below is the part that costs something.
         let head_before = chain.head_tip().map(|tip| tip.block_id);
-        if !orphaned.is_empty() {
-            let ids: Vec<u64> = orphaned.iter().map(|block| block.header.block_id).collect();
-            debug!(
-                "Channel orphaned {} block(s) {:?}..={:?}, head tip is {head_before:?}",
-                ids.len(),
-                ids.iter().min(),
-                ids.iter().max(),
-            );
-        }
+        log_update(&orphaned, &adopted, &finalized, head_before);
 
         // A pin that stops moving while the channel keeps going is a wedge, so
         // log each move.
@@ -1931,23 +1927,9 @@ async fn apply_follow_update<S: StorageActorTrait>(
             );
         }
 
-        // An adoption that does not apply freezes the head where it is, and
-        // every later one then fails the same way. Nothing else reports it.
-        for (block, outcome) in adopted.iter().zip(&outcomes) {
-            if let AcceptOutcome::Parked(err) | AcceptOutcome::RetryableFailure(err) = outcome {
-                warn!(
-                    "Adopted block {} did not apply, head stays at {:?}: {err}",
-                    block.header.block_id,
-                    chain.head_tip().map(|tip| tip.block_id),
-                );
-            }
-        }
-
-        if let (Some(before), Some(after)) = (head_before, chain.head_tip().map(|tip| tip.block_id))
-            && after < before
-        {
-            warn!("Head rewound from {before} to {after}");
-        }
+        let head_after = chain.head_tip().map(|tip| tip.block_id);
+        log_parked(&adopted, &outcomes, head_after, chain.channel_cursor());
+        log_rewind(head_before, head_after, chain.channel_cursor());
 
         let mut to_persist: Vec<&Block> = adopted
             .iter()
@@ -2039,6 +2021,8 @@ async fn apply_follow_update<S: StorageActorTrait>(
             (!orphans_above_head.is_empty() && none_back_on_channel && all_adopted_applied)
                 .then_some(head_height)
                 .flatten();
+
+        log_high_water_lowered(lower_published_high_water, &orphans_above_head);
 
         // Every block at or below the highest finalized one is irreversible, so
         // stored blocks there can be marked finalized.

--- a/lez/sequencer/core/src/logging.rs
+++ b/lez/sequencer/core/src/logging.rs
@@ -1,0 +1,100 @@
+//! Log lines for the follow and produce paths.
+//!
+//! Kept apart from the logic so the callers stay one line each.
+
+use chain_state::AcceptOutcome;
+use common::block::Block;
+use log::{info, warn};
+use logos_blockchain_zone_sdk::Slot;
+
+use crate::block_publisher::MsgId;
+
+/// `lo..=hi (n)` for a log line, flagged when the ids do not fill that range.
+pub(crate) fn id_span(ids: &[u64]) -> String {
+    match (ids.iter().min(), ids.iter().max()) {
+        (Some(lo), Some(hi)) => {
+            let span = hi.saturating_sub(*lo).saturating_add(1);
+            let contiguous = u64::try_from(ids.len()).is_ok_and(|len| len == span);
+            let gaps = if contiguous { "" } else { ", non-contiguous" };
+            format!("{lo}..={hi} ({}{gaps})", ids.len())
+        }
+        _ => "none".to_owned(),
+    }
+}
+
+pub(crate) fn block_ids(blocks: &[Block]) -> Vec<u64> {
+    blocks.iter().map(|block| block.header.block_id).collect()
+}
+
+/// The pin — the channel entry the next publish chains on — as a log field.
+pub(crate) fn pin_str(pin: Option<MsgId>) -> String {
+    pin.map_or_else(|| "none".to_owned(), |msg| msg.to_string())
+}
+
+/// The L2 view of one update: decoded heights and the head they meet.
+///
+/// Counts, entry ids and the channel tip are zone-sdk's `ChannelUpdate` debug
+/// line; this carries only what that cannot know.
+pub(crate) fn log_update(
+    orphaned: &[Block],
+    adopted: &[Block],
+    finalized: &[(Block, Slot)],
+    head: Option<u64>,
+) {
+    info!(
+        "Channel update: orphaned {}, adopted {}, finalized {}, head {head:?}",
+        id_span(&block_ids(orphaned)),
+        id_span(&block_ids(adopted)),
+        id_span(
+            &finalized
+                .iter()
+                .map(|(b, _)| b.header.block_id)
+                .collect::<Vec<_>>()
+        ),
+    );
+}
+
+/// Adoptions that did not apply, with the pin they were left behind by.
+pub(crate) fn log_parked(
+    adopted: &[Block],
+    outcomes: &[AcceptOutcome],
+    head: Option<u64>,
+    pin: Option<MsgId>,
+) {
+    for (block, outcome) in adopted.iter().zip(outcomes) {
+        if let AcceptOutcome::Parked(err) | AcceptOutcome::RetryableFailure(err) = outcome {
+            warn!(
+                "Adopted block {} did not apply, head stays at {head:?} with the pin at {}: {err}",
+                block.header.block_id,
+                pin_str(pin),
+            );
+        }
+    }
+}
+
+pub(crate) fn log_rewind(before: Option<u64>, after: Option<u64>, pin: Option<MsgId>) {
+    if let (Some(before), Some(after)) = (before, after)
+        && after < before
+    {
+        warn!(
+            "Head rewound from {before} to {after}, pin now {}",
+            pin_str(pin)
+        );
+    }
+}
+
+/// Dropping the mark permits a second block at a height already inscribed, so
+/// name the heights it frees: they are checkable on L1.
+pub(crate) fn log_high_water_lowered(mark: Option<u64>, orphans_above_head: &[&Block]) {
+    if let Some(mark) = mark {
+        let ids: Vec<u64> = orphans_above_head
+            .iter()
+            .map(|block| block.header.block_id)
+            .collect();
+        warn!(
+            "Lowering the published high water to {mark}, every height above it is writable \
+             again; orphaned above the head and not re-adopted: {}",
+            id_span(&ids),
+        );
+    }
+}

--- a/lez/sequencer/core/src/tests.rs
+++ b/lez/sequencer/core/src/tests.rs
@@ -1,4 +1,8 @@
-#![expect(clippy::shadow_unrelated, reason = "We don't care about it in tests")]
+#![expect(
+    clippy::shadow_unrelated,
+    clippy::arbitrary_source_item_ordering,
+    reason = "We don't care about it in tests"
+)]
 
 use std::{collections::HashSet, pin::pin, sync::Arc, time::Duration};
 
@@ -4864,5 +4868,66 @@ fn genesis_cross_zone_transactions_follow_the_declaration() {
     );
     for id in cross_zone_ids {
         assert!(state.get_program(ProgramId::from(id)).is_some());
+    }
+}
+
+mod channel_update_extraction {
+    use logos_blockchain_core::mantle::{
+        ops::{
+            Op,
+            channel::inscribe::{Inscription, InscriptionOp},
+        },
+        transactions::{MantleTxBuilder, OpsProofs, SignedMantleTx, states::Unverified},
+    };
+    use logos_blockchain_zone_sdk::sequencer::ChannelUpdateTx;
+
+    use super::{sequencer_sign_key_for_testing, *};
+    use crate::block_publisher::channel_blocks;
+
+    /// A tx wrapping `block` in one inscribe op on `channel`.
+    fn inscribing_tx(
+        channel: ChannelId,
+        block: &common::block::Block,
+    ) -> SignedMantleTx<Unverified> {
+        let inscription: Inscription = borsh::to_vec(block).expect("serialize").try_into().unwrap();
+        let op = Op::ChannelInscribe(InscriptionOp {
+            channel_id: channel,
+            inscription,
+            parent: MsgId::root(),
+            signer: Ed25519Key::generate(&mut rand::rngs::OsRng).public_key(),
+        });
+        let raw = MantleTxBuilder::new()
+            .extend_ops([op])
+            .expect("ops fit")
+            .build()
+            .expect("tx builds");
+        SignedMantleTx::new(raw, OpsProofs::empty())
+    }
+
+    #[test]
+    fn a_custom_tx_yields_its_block() {
+        let channel = ChannelId::from([1; 32]);
+        let block = HashableBlockData {
+            block_id: 7,
+            prev_block_hash: HashType([0; 32]),
+            timestamp: 700,
+            transactions: Vec::new(),
+        }
+        .into_pending_block(&sequencer_sign_key_for_testing());
+
+        let custom = ChannelUpdateTx::Custom(inscribing_tx(channel, &block));
+        let blocks = channel_blocks(&custom, channel);
+
+        assert_eq!(blocks.len(), 1, "the Custom tx carries one block");
+        assert_eq!(blocks[0].header.block_id, 7);
+        assert_eq!(blocks[0].header.hash, block.header.hash);
+    }
+
+    #[test]
+    fn a_config_tx_yields_nothing() {
+        let channel = ChannelId::from([1; 32]);
+        let raw = MantleTxBuilder::new().build().expect("tx builds");
+        let config = ChannelUpdateTx::Config(SignedMantleTx::new(raw, OpsProofs::empty()));
+        assert!(channel_blocks(&config, channel).is_empty());
     }
 }


### PR DESCRIPTION
## 🎯 Purpose

Add more logging on the sequencer for devnet debugging.

One unrelated fix found on the way.

## ⚙️ Approach

Logging, all extracted into free functions so `apply_follow_update` only calls them:

Unrelated fix: the orphan path dropped `ChannelUpdateTx::Custom`, while the adopt path decoded it. A block could be adopted into the head and never reverted out. Both directions now use one extractor.

## 🧪 How to Test

```
cargo test -p sequencer_core --features mock channel_update_extraction
cargo test -p sequencer_core --features mock
```

The new lines on a running node:

```
just run-bedrock
just run-sequencer
```

## 🔗 Dependencies

None.

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments

