### PR TITLE
ci: repair host cache saves, move valid-proof-test to nightly, cancel superseded runs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,13 @@
+# Timing visibility for CI. There is deliberately no `terminate-after`: some
+# tests legitimately run for many minutes, and the point here is to see which
+# ones, not to kill them.
+[profile.ci]
+# Print a SLOW line every period a test is still running, so the log shows the
+# expensive tests without needing the JUnit file.
+slow-timeout = { period = "120s" }
+# One failing test should not hide the timings of the rest.
+fail-fast = false
+status-level = "slow"
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/actions/run-in-ci-image/action.yml
+++ b/.github/actions/run-in-ci-image/action.yml
@@ -61,3 +61,19 @@ runs:
           "${env_args[@]}" \
           "$INPUT_IMAGE" \
           bash -e -o pipefail -c "$INPUT_RUN"
+
+    # The container runs as root, so everything it writes through a bind mount
+    # comes back root-owned and the unprivileged runner cannot tar it for the
+    # cache. Covers every mount above: rust-cache saves `.cargo/git` as well as
+    # `.cargo/registry`, so missing one still breaks the save. Runs on failure
+    # too, since a failed build leaves the same root-owned files behind.
+    - name: Restore workspace ownership
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo chown -R "$(id -u):$(id -g)" \
+          "$PWD" \
+          "$HOME/.cargo/registry" \
+          "$HOME/.cargo/git" \
+          "$HOME/.cache/logos/blockchain"

--- a/.github/scripts/with_retry.sh
+++ b/.github/scripts/with_retry.sh
@@ -14,7 +14,6 @@ with_retry() {
     if (( attempt < max_attempts )); then
       echo "::warning:: Attempt $attempt failed, cleaning up and retrying..." >&2
       rm -rf target/debug/deps/*.o target/debug/incremental 2>/dev/null || true
-      cargo clean -p integration_tests 2>/dev/null || true
       sleep 5
     fi
 

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -72,4 +72,4 @@ jobs:
           # access rules.
           labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
           cache-from: type=gha,scope=ci-image
-          cache-to: type=gha,mode=max,scope=ci-image
+          cache-to: type=gha,mode=min,scope=ci-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
       - "**.md"
       - "!.github/workflows/*.yml"
 
+# Supersede in-progress runs for a pull request; never cancel a push, so each
+# merge to main/dev keeps its own run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: read
@@ -111,7 +117,7 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-rust-cache
+          shared-key: ci-container
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
 
       - name: Lint workspace
@@ -141,14 +147,14 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-rust-cache
+          shared-key: ci-container
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
 
       - name: Run tests
         env:
           RISC0_DEV_MODE: "1"
           RUST_LOG: "info,kameo=warn"
-        run: cargo nextest run --workspace --exclude integration_tests --exclude test_fixtures --all-features
+        run: cargo nextest run --profile ci --workspace --exclude integration_tests --exclude test_fixtures --all-features
 
   # Not a `container:` job: the tests drive the host's Docker daemon through
   # testcontainers, so they run in the CI image via `run-in-ci-image` instead.
@@ -171,7 +177,7 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-rust-cache
+          shared-key: ci-host
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
 
       - name: Run test_fixtures tests
@@ -206,7 +212,7 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-rust-cache
+          shared-key: ci-host
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
 
       - name: Build integration test archive
@@ -216,7 +222,7 @@ jobs:
           env: RISC0_DEV_MODE=1
           run: |
               source .github/scripts/with_retry.sh
-              with_retry 'cargo nextest archive -p integration_tests --archive-file integration-tests.tar.zst --no-pager' 5 
+              with_retry 'cargo nextest archive -p integration_tests --archive-file integration-tests.tar.zst --no-pager' 2
 
       - name: Upload integration test archive
         uses: actions/upload-artifact@v4
@@ -294,42 +300,10 @@ jobs:
               # allowing TF to use its local build provider.
               cargo fetch --locked
 
-              with_retry 'env -u GITHUB_ACTIONS -u CI cargo nextest run --archive-file integration-tests.tar.zst -E "binary(${{ matrix.target }})"' 5
+              with_retry 'env -u GITHUB_ACTIONS -u CI cargo nextest run --archive-file integration-tests.tar.zst -E "binary(${{ matrix.target }})"' 2
             else
-              with_retry 'cargo nextest run --archive-file integration-tests.tar.zst -E "binary(${{ matrix.target }})"' 5
+              with_retry 'cargo nextest run --archive-file integration-tests.tar.zst -E "binary(${{ matrix.target }})"' 2
             fi
-
-  valid-proof-test:
-    needs: ci-image
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    timeout-minutes: 150
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.head_ref }}
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci-rust-cache
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
-
-      - name: Test valid proof
-        uses: ./.github/actions/run-in-ci-image
-        with:
-          image: ${{ needs.ci-image.outputs.image }}
-          env: RUST_LOG=info,kameo=warn
-          run: |
-              source .github/scripts/with_retry.sh
-              with_retry 'cargo test -p integration_tests -- --exact private::private_transfer_to_owned_account' 5 
 
   # `just build-artifacts` drives the host's Docker daemon via `cargo risczero
   # build`, so it goes through the image rather than `container:`.
@@ -354,7 +328,7 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-rust-cache
+          shared-key: ci-host
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
 
       - name: Build artifacts

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -35,7 +35,7 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKER_REGISTRY }}/${{ github.repository }}/risc0_base:sha-${{ github.sha }}
           cache-from: type=gha,scope=risc0-base
-          cache-to: type=gha,mode=max,scope=risc0-base
+          cache-to: type=gha,mode=min,scope=risc0-base
 
   publish:
     needs: risc0_base
@@ -99,4 +99,4 @@ jobs:
           build-args: ${{ matrix.build_args }}
           build-contexts: risc0_base=docker-image://${{ secrets.DOCKER_REGISTRY }}/${{ github.repository }}/risc0_base:sha-${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.name }}

--- a/.github/workflows/valid-proof-test.yml
+++ b/.github/workflows/valid-proof-test.yml
@@ -1,0 +1,54 @@
+# Real proving, without RISC0_DEV_MODE, of one private transfer end to end.
+#
+# Nightly rather than per-merge: the single proof takes ~60m on a standard
+# runner and was the whole critical path of a push run. The `auth_transfer`
+# integration shard already covers this test's logic under dev mode, so what is
+# left here is only "real proving still works", which a daily signal answers.
+name: Valid proof
+
+on:
+  schedule:
+    # 03:17 UTC. Off-peak, and off the hour so it does not pile onto the
+    # top-of-hour scheduling surge.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  ci-image:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/ci-image.yml
+
+  valid-proof-test:
+    needs: ci-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-host
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
+
+      - name: Test valid proof
+        uses: ./.github/actions/run-in-ci-image
+        with:
+          image: ${{ needs.ci-image.outputs.image }}
+          env: RUST_LOG=info,kameo=warn
+          run: |
+              source .github/scripts/with_retry.sh
+              with_retry 'cargo test -p integration_tests -- --exact private::private_transfer_to_owned_account' 1


### PR DESCRIPTION
## 🎯 Purpose

Two structural CI problems, both cheap to fix.

The host-runner Rust cache has never worked: `run-in-ci-image` runs docker as root, so `target/` comes back root-owned and the cache save dies with `tar: Permission denied`. `gh cache list` shows zero host-family entries. `integration-tests-prebuild`, which gates all 35 shards, compiles cold on every run (13m41s).

`valid-proof-test` is 78m and is the entire critical path of a merge run; everything else finishes by ~55m. Its 60m is one real proof, irreducible on a standard runner. The `auth_transfer` shard already covers that test under dev mode, so this job only establishes that real proving works, which is a daily property.

Expected: PR runs ~53m to ~40m, push runs ~83m to ~42m.

## ⚙️ Approach

- [x] Restore workspace ownership after `run-in-ci-image` so the cache can save
- [x] Move `valid-proof-test` to a nightly workflow with `workflow_dispatch`
- [x] Split `ci-rust-cache` into `ci-container` and `ci-host`, which were racing to save
- [x] Add top-level `concurrency:` so superseded PR runs cancel
- [x] Retries 5 to 2 (1 for the proof test), and no `cargo clean` between attempts
- [x] Buildkit `cache-to: mode=min`; the repo is at 11.28 GB against a 10 GB limit
- [x] Add a `ci` nextest profile so slow tests show up in the log

## 🧪 How to Test

The cache fix cannot show on this PR: `save-if` is limited to `main`/`dev`, so a PR branch never writes a cache. It populates on the first merge to `dev` and pays off from the run after.

After merge:

1. `gh cache list` shows `v0-rust-ci-host-*` entries, where there were none.
2. `integration-tests-prebuild` logs a cache restore and compiles well under 13m41s.
3. `gh workflow run valid-proof-test.yml` still passes in ~78m.
4. Push twice quickly to a PR branch; the first run cancels within seconds.

## 🔜 Future Work

- Route dev-mode proving through the existing `image_cache`, bypassed by ~76 `default_prover()` call sites, to cut the 25-35m `unit-tests` job.
- `image_cache` is behind `#[cfg(feature = "prove")]`, which the sequencer and indexer Dockerfiles do not enable, so the node still spawns r0vm per guest execution while CI does not.
- Rebalance the integration matrix: 35 shards, mean 10.6m, max 31m. Sharding is one per file, so it needs the file split.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [x] Add/update documentation and inline comments
