### PR TITLE
fix(keycard_wallet): send the SIGN tweak as zero, not the message alone

### DIFF
--- a/lez/keycard_wallet/src/lib.rs
+++ b/lez/keycard_wallet/src/lib.rs
@@ -211,8 +211,14 @@ impl KeycardWallet {
         path: &str,
         message: &[u8; 32],
     ) -> Result<(Signature, PublicKey), KeycardWalletError> {
+        // `SIGN` for BIP340_SCHNORR takes 64 bytes: the message plus a tweak the card adds to
+        // its already-derived key before signing. The card already applies LEE's key protocol (to
+        // obtain the Schnorr secret key), so the signing key here is already `ssk` — a
+        // nonzero tweak would double-tweak it and sign with the wrong key. Zero leaves it correct.
+        let mut data = [0_u8; 64];
+        data[..32].copy_from_slice(message);
         let resp = self.command_set.sign_with_path_and_algo(
-            message,
+            &data,
             path,
             sign_p2::BIP340_SCHNORR,
             false,


### PR DESCRIPTION
## 🎯 Purpose

*What problem does this PR solve or what feature does it add? Mention issues related to it*

TO COMPLETE

`SIGN` for BIP340_SCHNORR requires a 64-byte payload (message + tweak), not just the 32-byte message — the card was rejecting every signed transaction with a 0x6A80 "wrong data" error. The tweak must be zero: the card's own key derivation already applies LEE's tweak internally once it's in LEE mode, so the signing key is already the account's real `ssk` by the time SIGN runs. Sending a nonzero tweak here would double-tweak it and sign with the wrong key.



## ⚙️ Approach

*Describe the core changes introduced by this PR.*

TO COMPLETE

- [ ] Change ...
- [ ] Add ...
- [ ] Fix ...
- [ ] ...

## 🧪 How to Test

*How to verify that this PR works as intended.*

TO COMPLETE

## 🔗 Dependencies

*Link PRs that must be merged before this one.*

TO COMPLETE IF APPLICABLE

## 🔜 Future Work

*List any work intentionally left out of this PR, whether due to scope, prioritization, or pending decisions.*

TO COMPLETE IF APPLICABLE

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [ ] Complete PR description
- [ ] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments
