### PR TITLE
perf(lez): run guests in-process on the node via the memoized image cache

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -54,7 +54,7 @@ jobs:
           - name: sequencer_service-mdns
             dockerfile: ./lez/sequencer/service/Dockerfile
             build_args: |
-              FEATURES=mdns
+              FEATURES=prove,mdns
           - name: indexer_service
             dockerfile: ./lez/indexer/service/Dockerfile
             build_args: ""

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -70,6 +70,8 @@ sequencer_core = { workspace = true, features = ["test-utils"] }
 
 [features]
 cucumber = ["dep:cucumber"]
+# In-process guest execution with a memoized memory image, via `lee`.
+prove = ["lee/prove"]
 
 [[test]]
 harness = false                     # Cucumber has its own main() function to run tests.

--- a/lez/chain_state/Cargo.toml
+++ b/lez/chain_state/Cargo.toml
@@ -24,6 +24,11 @@ serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 
+[features]
+default = []
+# In-process guest execution with a memoized memory image, via `lee`.
+prove = ["lee/prove"]
+
 [dev-dependencies]
 testnet_initial_state.workspace = true
 serde_json.workspace = true

--- a/lez/indexer/core/Cargo.toml
+++ b/lez/indexer/core/Cargo.toml
@@ -9,6 +9,8 @@ workspace = true
 
 [features]
 default = []
+# In-process guest execution with a memoized memory image, via `lee`.
+prove = ["lee/prove", "chain_state/prove", "storage/prove"]
 
 [dependencies]
 chain_state.workspace = true

--- a/lez/indexer/service/Cargo.toml
+++ b/lez/indexer/service/Cargo.toml
@@ -26,3 +26,5 @@ arc-swap = "1.8.1"
 [features]
 # Return mock responses with generated data for testing purposes
 mock-responses = []
+# In-process guest execution with a memoized memory image, via `lee`.
+prove = ["indexer_core/prove"]

--- a/lez/indexer/service/Dockerfile
+++ b/lez/indexer/service/Dockerfile
@@ -3,6 +3,11 @@ FROM risc0_base AS chef
 
 WORKDIR /indexer_service
 
+# Comma-separated extra cargo features. Defaults to `prove`, which selects the
+# in-process guest executor with a memoized memory image instead of spawning an
+# r0vm subprocess per execution.
+ARG FEATURES="prove"
+
 # Planner stage - generates dependency recipe
 FROM chef AS planner
 COPY . .
@@ -10,13 +15,15 @@ RUN cargo chef prepare --bin indexer_service --recipe-path recipe.json
 
 # Builder stage - builds dependencies and application
 FROM chef AS builder
+ARG FEATURES
 COPY --from=planner /indexer_service/recipe.json recipe.json
 # Build dependencies only (this layer will be cached)
 RUN --mount=type=cache,target=/usr/local/cargo/registry/index \
     --mount=type=cache,target=/usr/local/cargo/registry/cache \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/indexer_service/target \
-    cargo chef cook --bin indexer_service --release --recipe-path recipe.json
+    cargo chef cook --bin indexer_service ${FEATURES:+--features "$FEATURES"} \
+      --release --recipe-path recipe.json
 
 # Copy source code
 COPY . .
@@ -26,7 +33,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry/index \
     --mount=type=cache,target=/usr/local/cargo/registry/cache \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/indexer_service/target \
-    cargo build --release --bin indexer_service \
+    cargo build --release ${FEATURES:+--features "$FEATURES"} --bin indexer_service \
     && strip /indexer_service/target/release/indexer_service \
     && cp /indexer_service/target/release/indexer_service /usr/local/bin/indexer_service
 

--- a/lez/sequencer/core/Cargo.toml
+++ b/lez/sequencer/core/Cargo.toml
@@ -54,6 +54,8 @@ thiserror.workspace = true
 
 [features]
 default = []
+# In-process guest execution with a memoized memory image, via `lee`.
+prove = ["lee/prove", "chain_state/prove"]
 # Generate mock external clients implementations for testing
 mock = []
 # Enable mDNS-based local peer discovery for gossip.

--- a/lez/sequencer/service/Cargo.toml
+++ b/lez/sequencer/service/Cargo.toml
@@ -44,6 +44,8 @@ required-features = ["submit_stake"]
 
 [features]
 default = []
+# In-process guest execution with a memoized memory image, via `lee`.
+prove = ["sequencer_core/prove"]
 # Runs the sequencer in standalone mode without depending on Bedrock and Indexer services.
 standalone = ["sequencer_core/mock"]
 # Enable mDNS-based local peer discovery for gossip.

--- a/lez/sequencer/service/Dockerfile
+++ b/lez/sequencer/service/Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /sequencer_service
 
 # Build argument to enable standalone feature (defaults to false)
 ARG STANDALONE=false
-# Comma-separated extra cargo features, e.g. FEATURES=mdns for LAN peer discovery
-ARG FEATURES=""
+# Comma-separated extra cargo features, e.g. FEATURES=mdns for LAN peer discovery.
+# Defaults to `prove`, which selects the in-process guest executor with a memoized
+# memory image instead of spawning an r0vm subprocess per execution.
+ARG FEATURES="prove"
 
 # Planner stage - generates dependency recipe
 FROM chef AS planner


### PR DESCRIPTION
## 🎯 Purpose

The sequencer and indexer build without `prove`, so `lee/state_machine/src/program/mod.rs:122` resolves to risc0's `ExternalProver`: a fresh r0vm subprocess per guest execution, an `r0vm --version` probe per call, and an ELF-to-memory-image rebuild every time. With `prove` the same call site uses `image_cache::execute`, which runs in-process against a memoized image. The two are selected by a hard `cfg`, and only `unit-tests` (via `--all-features`) has ever exercised the fast one.

Measured on one machine, `RISC0_DEV_MODE=1`, release:

| | subprocess | in-process |
|---|---|---|
| `storage` replay test (~1300 executions) | 45.96s | 3.19s |
| marginal block, one charged tx | ~690ms | ~50ms |
| `tps_test`, 1500 charged txs | failed, 0/1500 confirmed in the 187.5s window, 692s total | 65s, 23 TPS |

The last row is the headline: the node as it ships cannot reach the repo's own 8 TPS target, and reaches 23 TPS with this change.

Binary size is unchanged (40,707,392 vs 40,707,600 bytes) because only the executor is reachable and the proving circuits are dead-stripped. The cost is build time: 77 additional crates, seven of them native.

## ⚙️ Approach

- [x] Add a `prove` feature to `chain_state`, `sequencer_core`, `sequencer_service`, `indexer_core`, `indexer_service`, each forwarding to `lee/prove`, reusing the existing `storage/prove`
- [x] Default `FEATURES` to `prove` in both service Dockerfiles
- [x] `FEATURES=prove,mdns` for the `sequencer_service-mdns` image, which passed `FEATURES=mdns` and would otherwise have overridden the default and silently stayed on the subprocess path

## 🧪 How to Test

Confirm the executor actually changes, not just the feature:

    cargo tree -p sequencer_service -e normal -f "{p} :: {f}" | grep risc0-zkvm
    cargo tree -p sequencer_service --features prove -e normal -f "{p} :: {f}" | grep risc0-zkvm

`client,std` vs `client,prove,std`. Then reproduce the throughput difference:

    cargo test -p integration_tests --release --test tps -- --nocapture
    cargo test -p integration_tests --release --features prove --test tps -- --nocapture

## 🔜 Future Work

- Integration tests run the subprocess executor too, because `Cargo.toml:105` pins `wallet-ffi` with `default-features = false`. Wiring `prove` into the 35 CI shards was tried and abandoned: enabling it also flips `default_prover()` to `LocalProver`, whose dev-mode path unwraps at `dev_mode.rs:167` instead of returning an error, so `auth_transfer::private::ppt_cant_chain_call_faucet` panics where it used to get a clean `Err`. The speedup also looks small there, since integration tests wait on block timers rather than being executor-bound. Neither issue affects this PR: the services never call `default_prover()`.
- Drop the r0vm binary and `RISC0_SERVER_PATH` from both images once nothing can fall back to `ExternalProver`.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [x] Add/update documentation and inline comments

