### PR TITLE
ci: drop the unused junit output from the nextest ci profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,12 +2,9 @@
 # tests legitimately run for many minutes, and the point here is to see which
 # ones, not to kill them.
 [profile.ci]
-# Print a SLOW line every period a test is still running, so the log shows the
-# expensive tests without needing the JUnit file.
+# Print a SLOW line every period a test is still running, so the expensive
+# tests show up in the job log.
 slow-timeout = { period = "120s" }
 # One failing test should not hide the timings of the rest.
 fail-fast = false
 status-level = "slow"
-
-[profile.ci.junit]
-path = "junit.xml"


### PR DESCRIPTION
## 🎯 Purpose

The `ci` nextest profile added in #844 writes a `junit.xml` that nothing reads. No workflow uploads or parses it. Raised in review on #844 and answered there, but the change did not make it into that PR before it merged.

The rest of the profile stays: `slow-timeout` and `status-level = "slow"` are what actually give timing visibility, by putting SLOW lines in the job log.

## ⚙️ Approach

- [x] Drop `[profile.ci.junit]` from `.config/nextest.toml`
- [x] Reword the comment that referenced the JUnit file

## 🧪 How to Test

    cargo nextest show-config test-groups --profile ci

Exits 0, so the profile still parses. The only remaining `junit` reference in the repo is cucumber's own `output-junit` feature, which is unrelated and untouched.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [x] Add/update documentation and inline comments
