### PR TITLE
ci: stop gating integration shards on test-fixtures-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,17 @@ jobs:
             RUST_LOG=info,kameo=warn
           run: cargo nextest run -p test_fixtures
 
+  abort-on-stale-fixtures:
+    needs: test-fixtures-tests
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - run: gh run cancel ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   # Not a `container:` job: the test binaries bake CARGO_MANIFEST_DIR in at
   # compile time, so the archive has to be built on the same path the matrix
   # jobs later run it from.
@@ -328,7 +339,6 @@ jobs:
           echo "Discovered integration targets: $targets_json"
 
   integration-tests:
-    # Not gated on test-fixtures-tests: prebuild produces the archive.
     needs: [ci-image, bedrock-node, integration-tests-prebuild]
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,8 @@ jobs:
           echo "Discovered integration targets: $targets_json"
 
   integration-tests:
-    needs: [ci-image, bedrock-node, test-fixtures-tests, integration-tests-prebuild]
+    # Not gated on test-fixtures-tests: prebuild produces the archive.
+    needs: [ci-image, bedrock-node, integration-tests-prebuild]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:


### PR DESCRIPTION
## 🎯 Purpose

The integration shards wait on `test-fixtures-tests` before they start, but it doesn't produce anything they use. The archive comes from `integration-tests-prebuild`.

On the last dev run the archive was ready at +11m and the shards still didn't start until +30m, because `test-fixtures-tests` was ahead of them in the queue (it waits on `bedrock-node`, which takes 19m). Dropping it from `needs:` lets them start at +19m instead, so the run goes from ~53m to ~42m.

This wasn't worth doing before #874. Prebuild used to take 29m, so both finished around the same time and removing one changed nothing.

The gate was there to catch an outdated db dump before it breaks most of the integration tests. To keep that, `abort-on-stale-fixtures` cancels the run if `test-fixtures-tests` fails, so a stale dump still shows up as one clear failure instead of 35 confusing ones. The shards just don't wait for it any more.

## ⚙️ Approach

- [x] Drop `test-fixtures-tests` from the `integration-tests` `needs:` list
- [x] Cancel the run if `test-fixtures-tests` fails, so the check is preserved without the wait

## 🧪 How to Test

Next dev run, check when the shards start. Should be ~+19m rather than ~+30m, with the run landing around 42m.

The cancel path isn't exercised unless the dump actually goes stale. Worth knowing that it makes the run read as "cancelled" with `test-fixtures-tests` the single red job, rather than "failed".

## 🔜 Future Work

None.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [x] Add/update documentation and inline comments

